### PR TITLE
Remove Extra Columns from CSV Entries

### DIFF
--- a/dotgov-websites/other-websites.csv
+++ b/dotgov-websites/other-websites.csv
@@ -916,25 +916,25 @@ test.business.ftc.gov
 testold.ftc.gov
 vlan9-gw.ftc.gov
 vtc.ftc.gov
-advocatetoolkit.com, Treasury
-afsiep.net, Treasury
-goto188.com, Treasury
-improveirs.com, Treasury
-improveirs.net, Treasury
-improveirs.org, Treasury
-litctoolkit.com, Treasury
-nrcctxrelay.gov, Treasury
-tapspace.org, Treasury
-advocatetoolkit.com, Treasury
-afsiep.net, Treasury
-aseyenote.gov, Treasury
-goto188.com, Treasury
-improveirs.com, Treasury
-improveirs.net, Treasury
-improveirs.org, Treasury
-litctoolkit.com, Treasury
-nrcctxrelay.gov, Treasury
-tapspace.org, Treasury
+advocatetoolkit.com
+afsiep.net
+goto188.com
+improveirs.com
+improveirs.net
+improveirs.org
+litctoolkit.com
+nrcctxrelay.gov
+tapspace.org
+advocatetoolkit.com
+afsiep.net
+aseyenote.gov
+goto188.com
+improveirs.com
+improveirs.net
+improveirs.org
+litctoolkit.com
+nrcctxrelay.gov
+tapspace.org
 *.ecmapps.treasuryecm.gov
 abusive-trusts.irs.gov
 ansc.irs.gov


### PR DESCRIPTION
This PR fixes `dotgov-websites/other-websites.csv` so that is a consistently formatted CSV file. This file is a single field CSV and some of its entries include an unquoted comma (and additional data) which would indicate an additional field.