### PR TITLE
Add 11 non-.gov subdomains for FCC

### DIFF
--- a/dotgov-websites/other-websites.csv
+++ b/dotgov-websites/other-websites.csv
@@ -17011,3 +17011,14 @@ stgdaiss.thecommunityguide.org
 fcpre2.vetpro.org
 disasterloanassistance.sba.gov
 info.fcc.gov
+www.getemergencybroadband.org
+www.emergencyconnectivityfund.org
+www.checklifeline.org
+www.lifelinesupport.org
+ftp.lifelinesupport.org
+www.universalservicefund.org
+www.nanpfund.com
+secure.reassigned.us
+sftp.reassigned.us
+api.reassigned.us
+www.reassigned.us

--- a/dotgov-websites/other-websites.csv
+++ b/dotgov-websites/other-websites.csv
@@ -17011,14 +17011,7 @@ stgdaiss.thecommunityguide.org
 fcpre2.vetpro.org
 disasterloanassistance.sba.gov
 info.fcc.gov
-www.getemergencybroadband.org
-www.emergencyconnectivityfund.org
-www.checklifeline.org
-www.lifelinesupport.org
 ftp.lifelinesupport.org
-www.universalservicefund.org
-www.nanpfund.com
 secure.reassigned.us
 sftp.reassigned.us
 api.reassigned.us
-www.reassigned.us

--- a/dotgov-websites/other-websites.csv
+++ b/dotgov-websites/other-websites.csv
@@ -17011,7 +17011,14 @@ stgdaiss.thecommunityguide.org
 fcpre2.vetpro.org
 disasterloanassistance.sba.gov
 info.fcc.gov
+getemergencybroadband.org
+emergencyconnectivityfund.org
+checklifeline.org
+lifelinesupport.org
 ftp.lifelinesupport.org
+reassigned.us
 secure.reassigned.us
 sftp.reassigned.us
 api.reassigned.us
+universalservicefund.org
+nanpfund.com


### PR DESCRIPTION
FCC has requested we add a handful of non-.gov domains and subdomains to their BOD 18-01 reports. We have confirmed with them that the base domains of these subdomains (which were added at https://github.com/cisagov/scan-target-data/pull/53) are either owned/managed by FCC or operated specifically on their behalf.


