### PR TITLE
Remove srtr.org and its subdomains

### DIFF
--- a/dotgov-websites/other-websites.csv
+++ b/dotgov-websites/other-websites.csv
@@ -12217,7 +12217,6 @@ socdc1-vtccodec01.hhs.gov
 socdc1-vtcgk01.hhs.gov
 socdc1-vtcmcu01.hhs.gov
 soctms.hhs.gov
-srtr.org
 ssc.dhhs.gov
 ssc.psc.gov
 sscecom.psc.gov
@@ -12587,7 +12586,6 @@ www.safetyreporting.hhs.gov
 www.scholarship.ihs.gov
 www.shipnpr.acl.gov
 www.siteman.ihs.gov
-www.srtr.org
 www.staging.safetyreporting.hhs.gov
 www.staging2.safetyreporting.hhs.gov
 www.stg.adrc-tae.acl.gov
@@ -16981,13 +16979,6 @@ registration.scienceforum.sc
 registry.scienceforum.sc
 studyvisualsdev.scienceforum.sc
 workflow-dev.scienceforum.sc
-beta.srtr.org
-m.srtr.org
-report.srtr.org
-reportapi.srtr.org
-secure.srtr.org
-tools.srtr.org
-transfer.srtr.org
 amc.syndromicsurveillance.org
 dashboards.syndromicsurveillance.org
 dev-amc-prod.syndromicsurveillance.org


### PR DESCRIPTION
HHS has reported that these are not actually owned by nor managed on HHS' behalf.  HRSA only fund only the research but nothing else.


