### PR TITLE
Update from 24 Aug 2021

### DIFF
--- a/current-federal.csv
+++ b/current-federal.csv
@@ -150,7 +150,7 @@ NATIONALRESOURCEDIRECTORY.GOV,Federal Agency - Executive,Department of Defense,O
 NRD.GOV,Federal Agency - Executive,Department of Defense,OFFICE OF WARRIOR CARE POLICY,Arlington,VA,(blank)
 NRO.GOV,Federal Agency - Executive,Department of Defense,NRO,Chantilly,VA,bakersir@nro.mil
 NROJR.GOV,Federal Agency - Executive,Department of Defense,NRO,Chantilly,VA,hugheysh@nro.ic.gov
-NSA.GOV,Federal Agency - Executive,Department of Defense,NSA,Fort Meade,MD,(blank)
+NSA.GOV,Federal Agency - Executive,Department of Defense,NSA,Fort Meade,MD,ea_dns@nsa.gov
 NSEP.GOV,Federal Agency - Executive,Department of Defense,National Security Education Program (NSEP) at DLNSEO,Alexandria,VA,(blank)
 OEA.GOV,Federal Agency - Executive,Department of Defense,Office of Economic Adjustment,Arlington,VA,james.v.evans29.civ@mail.mil
 OLDCC.GOV,Federal Agency - Executive,Department of Defense,Office of Local Defense Community Cooperation,Arlington,VA,oea.ncr.OEA.mbx.oea-it-security@mail.mil
@@ -974,7 +974,7 @@ NEA.GOV,Federal Agency - Executive,National Endowment for the Arts,Office of Inf
 HUMANITIES.GOV,Federal Agency - Executive,National Endowment for the Humanities,Office of Information Resources Management,Washington,DC,dotgov@neh.gov
 NEH.GOV,Federal Agency - Executive,National Endowment for the Humanities,Office of Information Resources Management,Washington,DC,dotgov@neh.gov
 NGA.GOV,Federal Agency - Executive,National Gallery of Art,The National Gallery of Art,Washington,DC,soc@NGA.GOV
-NIGC.GOV,Federal Agency - Executive,National Indian Gaming Commission,National Indian Gaming Commision,Washington,DC,Jun_kim@nigc.gov
+NIGC.GOV,Federal Agency - Executive,National Indian Gaming Commission,National Indian Gaming Commision,Washington,DC,Jun.Kim@nigc.gov
 NLRB.GOV,Federal Agency - Executive,National Labor Relations Board,National Labor Relations Board,Washington,DC,vdp@nlrb.gov
 NMB.GOV,Federal Agency - Executive,National Mediation Board,National Mediation Board,Washington,DC,soc@nmb.gov
 NANO.GOV,Federal Agency - Executive,National Nanotechnology Coordination Office,National Nanotechnology Coordination Office,Arlington,VA,security@nnco.nano.gov

--- a/current-full.csv
+++ b/current-full.csv
@@ -122,6 +122,7 @@ ATKINSON-NH.GOV,City,Non-Federal Agency,Town of Atkinson,Atkinson,NH,support@blo
 ATLANTAGA.GOV,City,Non-Federal Agency,City of Atlanta,Atlanta,GA,tmunyengango@atlantaga.gov
 ATLANTISFL.GOV,City,Non-Federal Agency,City of Atlantis,Atlantis,FL,mlegall@atlantisfl.gov
 ATTICA-IN.GOV,City,Non-Federal Agency,City of Attica,Attica,IN,(blank)
+ATWATERMN.GOV,City,Non-Federal Agency,City of Atwater,Atwater,MN,atwatercityclerk@willmarnet.com
 AUBREYTX.GOV,City,Non-Federal Agency,City of Aubrey,Aubrey,TX,(blank)
 AUBURNMAINE.GOV,City,Non-Federal Agency,"City of Auburn, Maine",Auburn,ME,pfraser@auburnmaine.gov
 AUBURNNY.GOV,City,Non-Federal Agency,City of Auburn,Auburn,NY,(blank)
@@ -402,7 +403,7 @@ CARMELTOWNSHIP-MI.GOV,City,Non-Federal Agency,Carmel Township,CHARLOTTE,MI,(blan
 CARNATIONWA.GOV,City,Non-Federal Agency,City of Carnation,Carnation,WA,(blank)
 CARPINTERIACA.GOV,City,Non-Federal Agency,City of Carpinteria,Carpinteria,CA,licettem@ci.carpinteria.ca.us
 CARRBORONC.GOV,City,Non-Federal Agency,"Town of Carrboro, NC",Carrboro,NC,avogel@townofcarrboro.org
-CARROLLTON-GA.GOV,City,Non-Federal Agency,City of Carrollton,Carrollton,GA,(blank)
+CARROLLTON-GA.GOV,City,Non-Federal Agency,City of Carrollton,Carrollton,GA,rrivers@carrollton-ga.gov
 CARROLLTONTX.GOV,City,Non-Federal Agency,City of Carrollton,Carrollton,TX,security@cityofcarrollton.com
 CARSONCA.GOV,City,Non-Federal Agency,"City of Carson, California",Carson,CA,kkennedy@carson.ca.us
 CARTERLAKE-IA.GOV,City,Non-Federal Agency,City of Carter Lake,Carter Lake,IA,lisa.ruehle@carterlake-ia.gov
@@ -575,6 +576,7 @@ CITYOFLUBBOCKTX.GOV,City,Non-Federal Agency,"City of Lubbock, Texas",Lubbock,TX,
 CITYOFMACON-MO.GOV,City,Non-Federal Agency,City Of Macon,Macon,MO,info@cityofmacon-mo.gov
 CITYOFMADERA.GOV,City,Non-Federal Agency,City of Madera,Madera,CA,msouders@cityofmadera.com
 CITYOFMADISONWI.GOV,City,Non-Federal Agency,City of Madison,Madison,WI,(blank)
+CITYOFMANCHESTERTN.GOV,City,Non-Federal Agency,City Of Manchester,Manchester,TN,security@cityofmanchestertn.com
 CITYOFMARGARETALABAMA.GOV,City,Non-Federal Agency,City of Margaret,ODENVILLE,AL,mtortorice@gmail.com
 CITYOFMARIONIL.GOV,City,Non-Federal Agency,City of Marion,Marion,IL,cmoake@cityofmarionil.gov
 CITYOFMARIONWI.GOV,City,Non-Federal Agency,CITY OF MARION,MARION,WI,(blank)
@@ -769,7 +771,7 @@ CROSSROADSTX.GOV,City,Non-Federal Agency,Town of Cross Roads,Crossroads,TX,(blan
 CROSSVILLETN.GOV,City,Non-Federal Agency,City of Crossville,Crossville,TN,kyle.sherrill@crossvilletn.gov
 CROTONONHUDSON-NY.GOV,City,Non-Federal Agency,Village of Croton-on-Hudson,Croton-On-Hudson,NY,(blank)
 CRYSTALMN.GOV,City,Non-Federal Agency,City of Crystal,Crystal,MN,(blank)
-CRYSTALSPRINGSMS.GOV,City,Non-Federal Agency,City of Crystal Springs,Crystal Springs,MS,(blank)
+CRYSTALSPRINGSMS.GOV,City,Non-Federal Agency,City of Crystal Springs,Crystal Springs,MS,feliciadthompson@gmail.com
 CSTX.GOV,City,Non-Federal Agency,City of College Station,College Station,TX,(blank)
 CUBAASSESSORIL.GOV,City,Non-Federal Agency,Cuba Township,Barrington,IL,(blank)
 CUBATWPIL.GOV,City,Non-Federal Agency,Cuba Township,Barrington,IL,(blank)
@@ -794,7 +796,7 @@ DALLASOREGON.GOV,City,Non-Federal Agency,City of Dallas,Dallas,OR,(blank)
 DALTON-MA.GOV,City,Non-Federal Agency,Town of Dalton,Dalton,MA,(blank)
 DALTONGA.GOV,City,Non-Federal Agency,City of Dalton,Dalton,GA,(blank)
 DANBURY-CT.GOV,City,Non-Federal Agency,City of Danbury,Danbury,CT,(blank)
-DANBURYTX.GOV,City,Non-Federal Agency,City of Danbury,danbury,TX,heathermartin.danbury@gmail.com
+DANBURYTX.GOV,City,Non-Federal Agency,City of Danbury,danbury,TX,melindastrong77534@gmail.com
 DANDRIDGETN.GOV,City,Non-Federal Agency,Dandridge,Dandridge,TN,(blank)
 DANIABEACHFL.GOV,City,Non-Federal Agency,City of Dania Beach,DANIA BEACH,FL,(blank)
 DANVERSMA.GOV,City,Non-Federal Agency,Town of Danvers,Danvers,MA,it@danversma.gov
@@ -954,6 +956,7 @@ ELMWOODPLACE-OH.GOV,City,Non-Federal Agency,"M-Tec Systems, Inc",Cincinnati,OH,(
 ELON.GOV,City,Non-Federal Agency,Town of Elon,Elon,NC,mike@comtechnc.com
 ELOYAZ.GOV,City,Non-Federal Agency,City of Eloy,Eloy,AZ,(blank)
 ELPASOTEXAS.GOV,City,Non-Federal Agency,City of El Paso,El Paso,TX,IT-SecurityAssurance@elpasotexas.gov
+ELRENOOK.GOV,City,Non-Federal Agency,City of El Reno,El Reno,OK,it@cityofelreno.com
 EMERALDBAY-TX.GOV,City,Non-Federal Agency,Emerald Bay Municipal Utility District,Bullard,TX,(blank)
 EMMITSBURGMD.GOV,City,Non-Federal Agency,Emmitsburg Town Government,Emmitsburg,MD,tray@emmitsburgmd.gov
 EMPORIA-KANSAS.GOV,City,Non-Federal Agency,City Of Emporia,Emporia,KS,akenyon@emporia-kansas.gov
@@ -1294,7 +1297,7 @@ HEATHOHIO.GOV,City,Non-Federal Agency,"City of Heath, Ohio",Heath,OH,(blank)
 HEBERUT.GOV,City,Non-Federal Agency,Heber City Corporation,Heber City,UT,abeales@ci.heber.ut.us
 HEDWIGTX.GOV,City,Non-Federal Agency,Hedwig Village,Houston,TX,(blank)
 HELENAMT.GOV,City,Non-Federal Agency,City of Helena,Helena,MT,(blank)
-HELOTES-TX.GOV,City,Non-Federal Agency,City Of Helotes,Helotes,TX,(blank)
+HELOTES-TX.GOV,City,Non-Federal Agency,City Of Helotes,Helotes,TX,publicrelations@helotes-tx.gov
 HEMETCA.GOV,City,Non-Federal Agency,City of Hemet,HEMET,CA,(blank)
 HEMPSTEADNY.GOV,City,Non-Federal Agency,Town of Hempstead,Hempstead,NY,(blank)
 HEMPSTEADTOWNNY.GOV,City,Non-Federal Agency,Town of Hempstead,Hempstead,NY,(blank)
@@ -1420,6 +1423,7 @@ JACKSONTN.GOV,City,Non-Federal Agency,"City of Jackson, TN",Jackson,TN,btaylor@c
 JACKSONTOWNSHIP-PA.GOV,City,Non-Federal Agency,Jackson Township,Myerstown,PA,(blank)
 JACKSONTOWNSHIPPA.GOV,City,Non-Federal Agency,Jackson Township,Jackson Township,PA,(blank)
 JACKSONTWP-PA.GOV,City,Non-Federal Agency,Jackson Township,Reeders,PA,(blank)
+JACKSONVILLE.GOV,City,Non-Federal Agency,"City of Jacksonville, FL",Jacksonville,FL,abuse@coj.net
 JACKSONVILLEIL.GOV,City,Non-Federal Agency,CIty of Jacksonville,Jacksonville,IL,(blank)
 JACKSONVILLENC.GOV,City,Non-Federal Agency,City of Jacksonville,Jacksonville,NC,(blank)
 JACKSONWY.GOV,City,Non-Federal Agency,"Town of Jackson, Wyoming",Jackson,WY,(blank)
@@ -1690,7 +1694,7 @@ MAHOMET-IL.GOV,City,Non-Federal Agency,Village of Mahomet,Mahomet,IL,(blank)
 MAHWAH-NJ.GOV,City,Non-Federal Agency,Township of Mahwah,Mahwah,NJ,(blank)
 MAIDENNC.GOV,City,Non-Federal Agency,Town of Maiden,Maiden,NC,thawn@maidennc.gov
 MALIBU-CA.GOV,City,Non-Federal Agency,City of Malibu,Malibu,CA,(blank)
-MALVERNAR.GOV,City,Non-Federal Agency,City of Malvern,Malvern,AR,abuse@malvernar.gov
+MALVERNAR.GOV,City,Non-Federal Agency,City of Malvern,Malvern,AR,dis@malvernar.gov
 MANASQUAN-NJ.GOV,City,Non-Federal Agency,BOROUGH OF MANASQUAN,MANASQUAN,NJ,(blank)
 MANASSASPARKVA.GOV,City,Non-Federal Agency,City of Manassas Park,Manassas Park,VA,(blank)
 MANASSASVA.GOV,City,Non-Federal Agency,City of Manassas,Manassas,VA,securityadmins@manassasva.gov
@@ -2098,6 +2102,7 @@ ORANGE-CT.GOV,City,Non-Federal Agency,Town of Orange,Orange,CT,(blank)
 ORANGECITYFL.GOV,City,Non-Federal Agency,City of Orange City,Orange City,FL,mplace@ci.orange-city.fl.us
 ORANGENJ.GOV,City,Non-Federal Agency,CITY OF ORANGE TOWNSHIP,Orange,NJ,(blank)
 ORANGETEXAS.GOV,City,Non-Federal Agency,City of Orange Texas,Orange,TX,mzeto@orangepd.com
+ORLANDHILLSPDIL.GOV,City,Non-Federal Agency,Orland Hills Police Dept.,Orland Hills,IL,security@orlandhillspd.org
 ORLANDO.GOV,City,Non-Federal Agency,City of Orlando,Orlando,FL,(blank)
 ORLANDOFL.GOV,City,Non-Federal Agency,City of Orlando,Orlando,FL,(blank)
 ORONOCOTOWNSHIP-MN.GOV,City,Non-Federal Agency,Oronoco Township,Oronoco,MN,(blank)
@@ -2675,6 +2680,7 @@ SUPERIORCOLORADO.GOV,City,Non-Federal Agency,Town of Superior,Superior,CO,don.er
 SURFCITYNC.GOV,City,Non-Federal Agency,Town of Surf City,Surf City,NC,(blank)
 SURPRISEAZ.GOV,City,Non-Federal Agency,City of Surprise,Surprise,AZ,(blank)
 SWAMPSCOTTMA.GOV,City,Non-Federal Agency,Town of Swampscott,Swampscott,MA,bsheng@hiq.com
+SWANSEAMA.GOV,City,Non-Federal Agency,Town of Swansea,Swansea,MA,(blank)
 SWANZEYNH.GOV,City,Non-Federal Agency,Town of Swanzey,Swanzey,NH,allantreadwell@gsinet.net
 SWEENYTX.GOV,City,Non-Federal Agency,City of Sweeny,Sweeny,TX,(blank)
 SWEETHOMEOR.GOV,City,Non-Federal Agency,City of Sweet Home,Sweet Home,OR,(blank)
@@ -3142,6 +3148,7 @@ ALACHUACOUNTYFL.GOV,County,Non-Federal Agency,Alachua County BOCC,Gainesville,FL
 ALACHUACOUNTYFLA.GOV,County,Non-Federal Agency,Alachua County BOCC,Gainesville,FL,is_security@alachuacounty.us
 ALACHUACOUNTYFLORIDA.GOV,County,Non-Federal Agency,Alachua County BOCC,Gainesville,FL,is_security@alachuacounty.us
 ALBANYCOUNTYNY.GOV,County,Non-Federal Agency,Albany County,Albany,NY,(blank)
+ALCORNCOUNTYMS.GOV,County,Non-Federal Agency,Alcorn County Board of Supervisors,Corinth,MS,it@co.alcorn.ms.us
 ALEXANDERCOUNTY-NC.GOV,County,Non-Federal Agency,Alexander County NC,Taylorsville,NC,(blank)
 ALEXANDERCOUNTYNC.GOV,County,Non-Federal Agency,Alexander County NC,Taylorsville,NC,(blank)
 ALLEGHANYCOUNTY-NC.GOV,County,Non-Federal Agency,Alleghany County,Sparta,NC,info@imagingspecialists.net
@@ -3160,6 +3167,7 @@ APPOMATTOXCOUNTYVA.GOV,County,Non-Federal Agency,Appomattox County,Appomattox,VA
 ARANSASCOUNTYTX.GOV,County,Non-Federal Agency,"Aransas County, State of Texas",Rockport,TX,abuse@aransascountytx.gov
 ARENACCOUNTYMI.GOV,County,Non-Federal Agency,Arenac County Commissioners Office,Standish,MI,(blank)
 ARLINGTONCOUNTYVA.GOV,County,Non-Federal Agency,Arlington County Government,Arlington,VA,ddomain@arlingtonva.us
+ARLINGTONVA.GOV,County,Non-Federal Agency,Arlington County Government,Arlington,VA,ciso@arlingtonva.us
 ASCENSIONPARISHLA.GOV,County,Non-Federal Agency,Ascension Parish Government,Gonzales,LA,john.leblanc@apgov.us
 AUGLAIZECOUNTY-OHIO.GOV,County,Non-Federal Agency,Auglaize County,Wapakoneta,OH,cruppert@auglaizecounty.org
 AUGUSTACOUNTY-VA.GOV,County,Non-Federal Agency,County of Augusta,Verona,VA,jzetwick@co.augusta.va.us
@@ -3242,6 +3250,7 @@ BULLITTKY.GOV,County,Non-Federal Agency,Bullitt County Fiscal Court,Shepherdsvil
 BUREAUCOUNTY-IL.GOV,County,Non-Federal Agency,Bureau County,Princeton,IL,(blank)
 BURKECOUNTY-GA.GOV,County,Non-Federal Agency,Burke County Georgia,Waynesboro,GA,b.beauman@burkecounty-ga.gov
 BURNETTCOUNTYWI.GOV,County,Non-Federal Agency,Burnett County,Siren,WI,informationtechnology@burnettcounty.org
+BURTCOUNTYNE.GOV,County,Non-Federal Agency,"Burt County, NE",Tekamah,NE,clerk@burtcounty.org
 BUTLERCOUNTYPA.GOV,County,Non-Federal Agency,County of Butler PA,Butler,PA,mbargers@co.butler.pa.us
 CABARRUSCOUNTYNC.GOV,County,Non-Federal Agency,Cabarrus County Govt.,Concord,NC,(blank)
 CALCASIEUPARISH.GOV,County,Non-Federal Agency,Calcasieu Parish Police Jury,Lake Charles,LA,noc@cppj.net
@@ -3372,6 +3381,7 @@ CUYAHOGACOUNTY.GOV,County,Non-Federal Agency,Cuyahoga County,Cleveland,OH,securi
 CUYAHOGACOUNTYVOTESOH.GOV,County,Non-Federal Agency,Cuyahoga County Board of Elections,CLEVELAND,OH,rroy@cuyahogacounty.gov
 DADECOUNTY-GA.GOV,County,Non-Federal Agency,Dade County Georgia,Trenton,GA,djones@dadecounty-ga.gov
 DAKOTACOUNTYMN.GOV,County,Non-Federal Agency,Dakota County,Hastings,MN,david.senn@co.dakota.mn.us
+DALECOUNTYAL.GOV,County,Non-Federal Agency,Dale County ,Ozark,AL,admin@harlowmedia.com
 DALLASCOUNTY-TX.GOV,County,Non-Federal Agency,Dallas County,Dallas,TX,(blank)
 DALLASCOUNTYIOWA.GOV,County,Non-Federal Agency,Dallas County Iowa,Adel,IA,(blank)
 DALLASCOUNTYTEXASTAXES.GOV,County,Non-Federal Agency,Dallas Central Appraisal District,Dallas,TX,dcadops@dcad.org
@@ -3395,10 +3405,12 @@ DICKINSONCOUNTYIOWA.GOV,County,Non-Federal Agency,Dickinson County ,Spirit Lake,
 DICKINSONCOUNTYMI.GOV,County,Non-Federal Agency,Dickinson County,Iron Mountain,MI,(blank)
 DICKINSONCOUNTYSHERIFFMI.GOV,County,Non-Federal Agency,Dickinson County Sheriff,Iron Mountain,MI,pschlitt@dickinsoncountysheriffmi.gov
 DICKSONCOUNTYTN.GOV,County,Non-Federal Agency,Dickson County Government,Charlotte,TN,lwhitaker@dicksoncountytn.gov
+DIXONCOUNTYNE.GOV,County,Non-Federal Agency,"Dixon, County of",Ponca,NE,eknott@appliesconnective.com
 DKCOKS.GOV,County,Non-Federal Agency,"Dickinson County, KS",Abilene,KS,itstaff@dkcoks.org
 DODGECOUNTYNE.GOV,County,Non-Federal Agency,Dodge County,Fremont,NE,clerk@dodge.nacone.org
 DORCHESTERCOUNTYSC.GOV,County,Non-Federal Agency,Dorchester County Government,St. George,SC,(blank)
 DOUGLASCOUNTY-NE.GOV,County,Non-Federal Agency,Douglas Omaha Technology Commission,Omaha,NE,itsecurity@dotcomm.org
+DOUGLASCOUNTY-OREGON.GOV,County,Non-Federal Agency,"Douglas County, Oregon",Roseburg,OR,noc@co.douglas.or.us
 DOUGLASCOUNTYCOLORADO.GOV,County,Non-Federal Agency,Douglas County,Castle Rock,CO,itsecurity@douglas.co.us
 DOUGLASCOUNTYGA.GOV,County,Non-Federal Agency,Douglas County,Douglassville,GA,rdouglas@co.douglas.ga.us
 DOUGLASCOUNTYNV.GOV,County,Non-Federal Agency,Douglas County,Minden,NV,(blank)
@@ -3481,6 +3493,7 @@ GLOUCESTERCOUNTYNJ.GOV,County,Non-Federal Agency,County of Gloucester,Woodbury,N
 GLYNNCOUNTY-GA.GOV,County,Non-Federal Agency,Glynn County Board of Commissioners,Brunswick,GA,dbragdon@glynncounty-ga.gov
 GOGEBICCOUNTYMI.GOV,County,Non-Federal Agency,Gogebic County,Bessemer,MI,(blank)
 GOLIADCOUNTYTX.GOV,County,Non-Federal Agency,Goliad County,Goliad,TX,(blank)
+GOODHUECOUNTYMN.GOV,County,Non-Federal Agency,"Goodhue County, MN",Red Wing,MN,gc_it@co.goodhue.mn.us
 GRADYCOUNTYGA.GOV,County,Non-Federal Agency,Grady County Board of Commissioners,Cairo,GA,bjohnson@gradyco.org
 GRAINGERCOUNTYTN.GOV,County,Non-Federal Agency,Tennessee,Rutledge,TN,(blank)
 GRANTCOUNTY-OR.GOV,County,Non-Federal Agency,Grant County Court,Canyon City,OR,(blank)
@@ -3533,6 +3546,7 @@ HANOVER.GOV,County,Non-Federal Agency,Hanover County,Hanover,VA,jrwaters@hanover
 HANOVERCOUNTY.GOV,County,Non-Federal Agency,Hanover County,Hanover,VA,jrwaters@hanovercounty.gov
 HANOVERCOUNTYVA.GOV,County,Non-Federal Agency,Hanover County,Hanover,VA,jrwaters@hanovercounty.gov
 HARALSONCOUNTYGA.GOV,County,Non-Federal Agency,Haralson County Commissioner,Buchanan,GA,hcit@haralsoncountyga.gov
+HARDEECOUNTYFL.GOV,County,Non-Federal Agency,Hardee County BOCC,Wauchula,FL,bryan.mccall@hardeecounty.net
 HARDINCOUNTYIA.GOV,County,Non-Federal Agency,Hardin County,Eldora,IA,it@hardincountyia.gov
 HARFORDCOUNTYMD.GOV,County,Non-Federal Agency,Harford County Government,Bel Air,MD,(blank)
 HARPERCOUNTYKS.GOV,County,Non-Federal Agency,Harper County Kansas,Anthony,KS,Security@HarperCountyKS.gov
@@ -3591,6 +3605,7 @@ JEFFERSONCOUNTYAR.GOV,County,Non-Federal Agency,Jefferson County,Pine Bluff,AR,(
 JEFFERSONCOUNTYARCOURTS.GOV,County,Non-Federal Agency,Jefferson County Circuit Courts,Pine Bluff,AR,(blank)
 JEFFERSONCOUNTYFL.GOV,County,Non-Federal Agency,Jefferson County Board of County Commissioners,Monticello,FL,(blank)
 JEFFERSONCOUNTYGA.GOV,County,Non-Federal Agency,JEFFERSON COUNTY BOARD OF COMMISSIONERS,LOUISVILLE,GA,(blank)
+JEFFERSONCOUNTYKS.GOV,County,Non-Federal Agency,"Jefferson County, Kansas",Oskaloosa,KS,IT@jfcountyks.com
 JEFFERSONCOUNTYMS.GOV,County,Non-Federal Agency,Jefferson County Board of Supervisors,Fayette,MS,(blank)
 JEFFERSONCOUNTYTN.GOV,County,Non-Federal Agency,"Jefferson County, Tennessee",Dandridge,TN,mbolton@jeffersoncountytn.gov
 JEFFERSONCOUNTYWI.GOV,County,Non-Federal Agency,Jefferson County,Jefferson,WI,(blank)
@@ -4325,7 +4340,7 @@ NATIONALRESOURCEDIRECTORY.GOV,Federal Agency - Executive,Department of Defense,O
 NRD.GOV,Federal Agency - Executive,Department of Defense,OFFICE OF WARRIOR CARE POLICY,Arlington,VA,(blank)
 NRO.GOV,Federal Agency - Executive,Department of Defense,NRO,Chantilly,VA,bakersir@nro.mil
 NROJR.GOV,Federal Agency - Executive,Department of Defense,NRO,Chantilly,VA,hugheysh@nro.ic.gov
-NSA.GOV,Federal Agency - Executive,Department of Defense,NSA,Fort Meade,MD,(blank)
+NSA.GOV,Federal Agency - Executive,Department of Defense,NSA,Fort Meade,MD,ea_dns@nsa.gov
 NSEP.GOV,Federal Agency - Executive,Department of Defense,National Security Education Program (NSEP) at DLNSEO,Alexandria,VA,(blank)
 OEA.GOV,Federal Agency - Executive,Department of Defense,Office of Economic Adjustment,Arlington,VA,james.v.evans29.civ@mail.mil
 OLDCC.GOV,Federal Agency - Executive,Department of Defense,Office of Local Defense Community Cooperation,Arlington,VA,oea.ncr.OEA.mbx.oea-it-security@mail.mil
@@ -5149,7 +5164,7 @@ NEA.GOV,Federal Agency - Executive,National Endowment for the Arts,Office of Inf
 HUMANITIES.GOV,Federal Agency - Executive,National Endowment for the Humanities,Office of Information Resources Management,Washington,DC,dotgov@neh.gov
 NEH.GOV,Federal Agency - Executive,National Endowment for the Humanities,Office of Information Resources Management,Washington,DC,dotgov@neh.gov
 NGA.GOV,Federal Agency - Executive,National Gallery of Art,The National Gallery of Art,Washington,DC,soc@NGA.GOV
-NIGC.GOV,Federal Agency - Executive,National Indian Gaming Commission,National Indian Gaming Commision,Washington,DC,Jun_kim@nigc.gov
+NIGC.GOV,Federal Agency - Executive,National Indian Gaming Commission,National Indian Gaming Commision,Washington,DC,Jun.Kim@nigc.gov
 NLRB.GOV,Federal Agency - Executive,National Labor Relations Board,National Labor Relations Board,Washington,DC,vdp@nlrb.gov
 NMB.GOV,Federal Agency - Executive,National Mediation Board,National Mediation Board,Washington,DC,soc@nmb.gov
 NANO.GOV,Federal Agency - Executive,National Nanotechnology Coordination Office,National Nanotechnology Coordination Office,Arlington,VA,security@nnco.nano.gov
@@ -5512,6 +5527,7 @@ SUMMITCOUNTYBOE.GOV,Independent Intrastate Agency,Non-Federal Agency,Summit Coun
 SWA-IL.GOV,Independent Intrastate Agency,Non-Federal Agency,Southland Water Agency,South Holland,IL,Security@southholland.org
 SWCLEANAIR.GOV,Independent Intrastate Agency,Non-Federal Agency,Southwest Clean Air Agency,Vancouver,WA,chip@swcleanair.org
 SWOCAOH.GOV,Independent Intrastate Agency,Non-Federal Agency,SouthWest Ohio Computer Assocuation COG,Hamilton,OH,net@swoca.net
+TBLD.GOV,Independent Intrastate Agency,Non-Federal Agency,Tensas Basin Levee District,Monroe,LA,jason.mcmillin@la.gov
 TECHSHARETX.GOV,Independent Intrastate Agency,Non-Federal Agency,TechShare Local Government Corporation,Austin,TX,it.helpdesk@cuc.org
 TEXASCOUNTYMO911.GOV,Independent Intrastate Agency,Non-Federal Agency,Texas County Emergency Services,Houston,MO,kdrake@cbs-solutions.com
 THA.GOV,Independent Intrastate Agency,Non-Federal Agency,Topeka Housing Authority,Topeka,KS,(blank)
@@ -6227,6 +6243,7 @@ KSCJIS.GOV,State,Non-Federal Agency,Kansas Highway Patrol,Topeka,KS,(blank)
 KSREADY.GOV,State,Non-Federal Agency,Kansas Division of Emergency Management,Topeka,KS,(blank)
 KY.GOV,State,Non-Federal Agency,Commonwealth of Kentucky,Frankfort,KY,davidj.carter@ky.gov
 KYCOURTS.GOV,State,Non-Federal Agency,Administrative Office of the Courts,Frankfort,KY,infrastructure_Services_Security@kycourts.net
+KYNECT.GOV,State,Non-Federal Agency,Commonwealth of Kentucky Cabinet for Health and Family Services,Frankfort,KY,jeremy.rogers@ky.gov
 LA.GOV,State,Non-Federal Agency,State of Louisiana - Office of Technology Services,Baton Rouge,LA,(blank)
 LAFASTSTART.GOV,State,Non-Federal Agency,Louisiana Economic Development,Baton Rouge,LA,nicloaus.james@la.gov
 LAJUDICIAL.GOV,State,Non-Federal Agency,State of Louisiana Judicial Branch,New Orleans,LA,iteam@lasc.org
@@ -6467,6 +6484,7 @@ NV529.GOV,State,Non-Federal Agency,Nevada State Treasurer's Office,Carson City,N
 NVAGOMLA.GOV,State,Non-Federal Agency,NV Office of the Attorney General,Carson City,NV,(blank)
 NVCOGCT.GOV,State,Non-Federal Agency,Naugatuck Valley Council of Governments,Waterbury,CT,nvcog@nvcogct.org
 NVCOURTS.GOV,State,Non-Federal Agency,Supreme Court of Nevada,Carson City,NV,(blank)
+NVDPS.GOV,State,Non-Federal Agency,Enterprise IT Services Division,Carson City,NV,iso@dps.state.nv.us
 NVDPSPUB.GOV,State,Non-Federal Agency,Nevada Department of Public Safety,Carson City,NV,dmchugh@admin.nv.gov
 NVEASE.GOV,State,Non-Federal Agency,Nevada Secretary of State,Carson City,NV,(blank)
 NVGGMS.GOV,State,Non-Federal Agency,Nevada State Treasurer,Carson City,NV,security-abuse@nevadatreasurer.gov


### PR DESCRIPTION
A pull from the .gov registrar on Tuesday, the 24th of August, twentytwentyone. 

18 new domains since last update. 2 of note are domains for Arlington, VA (`arlingtonva.gov`) and Jacksonville, FL (`jacksonville.gov`).