### PR TITLE
Update from 4 Oct 2021

### DIFF
--- a/current-federal.csv
+++ b/current-federal.csv
@@ -181,6 +181,7 @@ DOEAL.GOV,Federal Agency - Executive,Department of Energy,NNSA,Albuquerque,NM,Co
 EIA.GOV,Federal Agency - Executive,Department of Energy,Energy Information Administration,Washington,DC,marc.cree@eia.gov
 ENERGY.GOV,Federal Agency - Executive,Department of Energy,"US Department of Energy, Office of the CIO",Washington,DC,CIRC@JC3.DOE.GOV
 ENERGYCODES.GOV,Federal Agency - Executive,Department of Energy,Department of Energy Bulding Energy Codes Program,Richland,WA,CIRC@JC3.DOE.GOV
+ENERGYCOMMUNITIES.GOV,Federal Agency - Executive,Department of Energy,"US Department of Energy, Office of the CIO",Washington,DC,CIRC@JC3.DOE.GOV
 ENERGYSAVER.GOV,Federal Agency - Executive,Department of Energy,Office of Energy Efficiency and Renewable Energy,Washington,DC,CIRC@JC3.DOE.GOV
 ENERGYSAVERS.GOV,Federal Agency - Executive,Department of Energy,Office of Energy Efficiency and Renewable Energy,Washington,DC,CIRC@JC3.DOE.GOV
 FNAL.GOV,Federal Agency - Executive,Department of Energy,Fermi National Accelerator Laboratory,Batavia,IL,security@fnal.gov
@@ -206,6 +207,7 @@ NUCLEAR.GOV,Federal Agency - Executive,Department of Energy,US Department of Ene
 ORAU.GOV,Federal Agency - Executive,Department of Energy,ORAU,Oak Ridge,TN,CIRC@JC3.DOE.GOV
 ORNL.GOV,Federal Agency - Executive,Department of Energy,Oak Ridge National Laboratory,Oak Ridge,TN,security@ornl.gov
 OSTI.GOV,Federal Agency - Executive,Department of Energy,OSTI,Oak Ridge,TN,security@osti.gov
+PCAST.GOV,Federal Agency - Executive,Department of Energy,U.S. Department of Energy,Washington,DC,CIRC@JC3.DOE.GOV
 PNL.GOV,Federal Agency - Executive,Department of Energy,Pacific Northwest National Laboratory,Richland,WA,CIRC@JC3.DOE.GOV
 PNNL.GOV,Federal Agency - Executive,Department of Energy,Pacific Northwest National Laboratory,Richland,WA,CIRC@JC3.DOE.GOV
 PPPL.GOV,Federal Agency - Executive,Department of Energy,Princeton Plasma Physics Lab,Princeton,NJ,security@pppl.gov
@@ -362,6 +364,7 @@ LISTO.GOV,Federal Agency - Executive,Department of Homeland Security,Office of P
 NIC.GOV,Federal Agency - Executive,Department of Homeland Security,Cybersecurity and Infrastructure Security Agency,Arlington,VA,vulnerability.disclosure.prog@hq.dhs.gov
 NIEM.GOV,Federal Agency - Executive,Department of Homeland Security,"Department of Homeland Security, Office of the Chief Information Officer",Washington,DC,IS2OSecurity@hq.dhs.gov
 NMSC.GOV,Federal Agency - Executive,Department of Homeland Security,National Marine Center,St Augustine,FL,bertram.dobrie@cbp.dhs.gov
+POWER2PREVENT.GOV,Federal Agency - Executive,Department of Homeland Security,Headquarters,Washington,DC,is2osecurity@hq.dhs.gov
 READY.GOV,Federal Agency - Executive,Department of Homeland Security,Office of Public Affairs,Washington,DC,fema-soc@fema.dhs.gov
 READYBUSINESS.GOV,Federal Agency - Executive,Department of Homeland Security,FEMA,Washington,DC,fema-soc@fema.dhs.gov
 SAFETYACT.GOV,Federal Agency - Executive,Department of Homeland Security,Science and Technology,Washington,DC,malik.locket@st.dhs.gov
@@ -843,7 +846,6 @@ FAPIIS.GOV,Federal Agency - Executive,General Services Administration,"GSA, IQ, 
 FBF.GOV,Federal Agency - Executive,General Services Administration,"GSA, IQ-CAP",Washington,DC,gsa-vulnerability-reports@gsa.gov
 FBO.GOV,Federal Agency - Executive,General Services Administration,"GSA, IC, Acquisition",Arlington,VA,gsa-vulnerability-reports@gsa.gov
 FDMS.GOV,Federal Agency - Executive,General Services Administration,"GSA, IQ, eRulemaking",Washington,DC,gsa-vulnerability-reports@gsa.gov
-FEDBIZOPPS.GOV,Federal Agency - Executive,General Services Administration,"GSA, IC, OGP Web Portfolio",Arlington,VA,gsa-vulnerability-reports@gsa.gov
 FEDIDCARD.GOV,Federal Agency - Executive,General Services Administration,"GSA, IQ, CAT",Washington,DC,gsa-vulnerability-reports@gsa.gov
 FEDINFO.GOV,Federal Agency - Executive,General Services Administration,"GSA, TTS",Washington,DC,gsa-vulnerability-reports@gsa.gov
 FEDRAMP.GOV,Federal Agency - Executive,General Services Administration,"GSA, TTS",Washington,DC,gsa-vulnerability-reports@gsa.gov
@@ -1034,7 +1036,7 @@ PBRB.GOV,Federal Agency - Executive,Public Buildings Reform Board,General Servic
 RRB.GOV,Federal Agency - Executive,Railroad Retirement Board,Bureau of Information Services,Chicago,IL,security@rrb.gov
 INVESTOR.GOV,Federal Agency - Executive,Securities and Exchange Commission,Network Operations Branch,Washington,DC,security@sec.gov
 SEC.GOV,Federal Agency - Executive,Securities and Exchange Commission,Network Operations Branch,Washington,DC,security@sec.gov
-SSS.GOV,Federal Agency - Executive,Selective Service System,Selective Service System,Arlington,VA,itsupport@sss.gov
+SSS.GOV,Federal Agency - Executive,Selective Service System,Selective Service System,Arlington,VA,soc@sss.gov
 BUSINESS.GOV,Federal Agency - Executive,Small Business Administration,U.S. Small Business Administration,Washington,DC,CISO@sba.gov
 NWBC.GOV,Federal Agency - Executive,Small Business Administration,U.S. Small Business Administration,Washington,DC,CISO@sba.gov
 SBA.GOV,Federal Agency - Executive,Small Business Administration,U.S. Small Business Administration,Washington,DC,CISO@sba.gov
@@ -1153,7 +1155,7 @@ PACER.GOV,Federal Agency - Judicial,U.S. Courts,Administrative Office U.S. Court
 USBANKRUPTCY.GOV,Federal Agency - Judicial,U.S. Courts,Administrative Office U.S. Courts,Washington,DC,(blank)
 USC.GOV,Federal Agency - Judicial,U.S. Courts,U.S. Courts,Washington,DC,(blank)
 USCAVC.GOV,Federal Agency - Judicial,U.S. Courts,US Court of Appeals for Veterans Claims,Washington,DC,(blank)
-USCOURTS.GOV,Federal Agency - Judicial,U.S. Courts,U.S. Courts,Washington,DC,(blank)
+USCOURTS.GOV,Federal Agency - Judicial,U.S. Courts,U.S. Courts,Washington,DC,security@uscourts.gov
 USPROBATION.GOV,Federal Agency - Judicial,U.S. Courts,Administrative Office U.S. Courts,Washington,DC,(blank)
 USSC.GOV,Federal Agency - Judicial,U.S. Courts,US Sentencing Commission,Washington,DC,(blank)
 USTAXCOURT.GOV,Federal Agency - Judicial,U.S. Courts,United States Tax Court,Washington,DC,(blank)
@@ -1271,6 +1273,6 @@ AMERICA250.GOV,Federal Agency - Legislative,U.S. Semiquincentennial Commission,U
 USA250.GOV,Federal Agency - Legislative,U.S. Semiquincentennial Commission,United States Semiquincentennial Commission,Washington D.C.,DC,shommel@america250.org
 USSEMIQUINCENTENNIAL.GOV,Federal Agency - Legislative,U.S. Semiquincentennial Commission,United States Semiquincentennial Commission,Washington D.C.,DC,shommel@america250.org
 USCC.GOV,Federal Agency - Legislative,U.S.-China Economic and Security Review Commission,U.S. - China Economic and Security Review Commission,Washington,DC,(blank)
-SEN.GOV,Federal Agency - Legislative,United States Senate,US Senate,Washington,DC,(blank)
+SEN.GOV,Federal Agency - Legislative,United States Senate,US Senate,Washington,DC,saanoc2@saa.senate.gov
 SENATE.GOV,Federal Agency - Legislative,United States Senate,US Senate,Washington,DC,saanoc2@saa.senate.gov
 WHDPC.GOV,Federal Agency - Legislative,Western Hemisphere Drug Policy Commission,Western Hemisphere Drug Policy Commission,"Washington,",MD,mary.speck@whdpc.gov

--- a/current-full.csv
+++ b/current-full.csv
@@ -1,6 +1,6 @@
 Domain Name,Domain Type,Agency,Organization,City,State,Security Contact Email
 ABERDEENMD.GOV,City,Non-Federal Agency,City of Aberdeen,Aberdeen,MD,(blank)
-ABERDEENWA.GOV,City,Non-Federal Agency,City of Aberdeen,Aberdeen,WA,(blank)
+ABERDEENWA.GOV,City,Non-Federal Agency,City of Aberdeen,Aberdeen,WA,wschmidt@aberdeenwa.gov
 ABILENETX.GOV,City,Non-Federal Agency,City of Abilene,Abilene,TX,bobvw@abilenetx.gov
 ABINGDON-VA.GOV,City,Non-Federal Agency,Town of Abingdon,Abingdon,VA,jcoggin@abingdon-va.gov
 ABINGTONMA.GOV,City,Non-Federal Agency,Town of Abington,Abington,MA,wnorling@abingtonma.gov
@@ -133,7 +133,7 @@ AUGUSTAGA.GOV,City,Non-Federal Agency,City of Augusta,Augusta,GA,(blank)
 AUGUSTAMAINE.GOV,City,Non-Federal Agency,City of Augusta,Augusta,ME,mike.schriver@augustamaine.gov
 AURORAMARIONVILLEPD-MO.GOV,City,Non-Federal Agency,Aurora Marionville Police Dept,Aurora,MO,(blank)
 AURORAMO.GOV,City,Non-Federal Agency,City of Aurora,Aurora,MO,(blank)
-AURORATEXAS.GOV,City,Non-Federal Agency,City of Aurora Texas,Rhome,TX,cityadministrator@auroratexas.gov
+AURORATEXAS.GOV,City,Non-Federal Agency,City of Aurora Texas,Rhome,TX,t.wheeler@auroratexas.gov
 AUSTELLGA.GOV,City,Non-Federal Agency,City of Austell ,Austell,GA,(blank)
 AUSTIN.GOV,City,Non-Federal Agency,City of Austin,Austin,TX,csirt@austintexas.gov
 AUSTINTEXAS.GOV,City,Non-Federal Agency,City of Austin,Austin,TX,csirt@austintexas.gov
@@ -427,6 +427,7 @@ CASTLEHILLS-TX.GOV,City,Non-Federal Agency,City of Castle Hills,Castle Hills,TX,
 CASTLEPINESCO.GOV,City,Non-Federal Agency,City Of Castle Pines,Castle Pines,CO,tobi@castlepinesco.gov
 CASTROVILLETX.GOV,City,Non-Federal Agency,City of Castroville,Castroville,TX,(blank)
 CATHEDRALCITY.GOV,City,Non-Federal Agency,City of Cathedral City,Cathedral City,CA,(blank)
+CATLETTSBURGKY.GOV,City,Non-Federal Agency,City of Catlettsburg,Catlettsburg,KY,faithday@catlettsburg.us
 CAVALIERND.GOV,City,Non-Federal Agency,City of Cavalier,Cavalier,ND,ktruver@nd.gov
 CAVECREEKAZ.GOV,City,Non-Federal Agency,Town of Cave Creek,Cave Creek,AZ,informationtechnology@cavecreek.org
 CAVESPRINGSAR.GOV,City,Non-Federal Agency,City of Cave Springs,Cave Springs,AR,(blank)
@@ -512,6 +513,7 @@ CITYOFALMAGA.GOV,City,Non-Federal Agency,The City of Alma Georgia,Alma,GA,(blank
 CITYOFALMATX.GOV,City,Non-Federal Agency,City of Alma,Alma,TX,(blank)
 CITYOFAPALACHICOLAFL.GOV,City,Non-Federal Agency,City of Apalachicola,Apalachicola,FL,security@cityofapalachicola.com
 CITYOFAUBURNWA.GOV,City,Non-Federal Agency,City of Auburn,Auburn,WA,servicedesk@auburnwa.gov
+CITYOFBAMBERGSC.GOV,City,Non-Federal Agency,City of Bamberg,Bamberg,SC,ahlink@atlanticbb.net
 CITYOFBENTONHARBORMI.GOV,City,Non-Federal Agency,City of Benton Harbor,Benton Harbor,MI,(blank)
 CITYOFBLANCOTX.GOV,City,Non-Federal Agency,City of Blanco,Blanco,TX,mayor@cityofblanco.com
 CITYOFBLUERIDGEGA.GOV,City,Non-Federal Agency,City of Blue Ridge,Blue Ridge,GA,(blank)
@@ -573,6 +575,7 @@ CITYOFHUMBLE-TX.GOV,City,Non-Federal Agency,City of Humble,Humble,TX,ticketing@b
 CITYOFHUMBLETX.GOV,City,Non-Federal Agency,City of Humble,Humble,TX,(blank)
 CITYOFHUNTSVILLETX.GOV,City,Non-Federal Agency,City of Huntsville,Huntsville,TX,(blank)
 CITYOFIRONDALEAL.GOV,City,Non-Federal Agency,City Of Irondale,Irondale,AL,(blank)
+CITYOFKASAANAK.GOV,City,Non-Federal Agency,City of Kasaan,Kasaan,AK,kasaancityclerk@gmail.com
 CITYOFKEYWEST-FL.GOV,City,Non-Federal Agency,City of Key West,Key West,FL,(blank)
 CITYOFKINGMAN.GOV,City,Non-Federal Agency,City of Kingman,Kingman,AZ,it@cityofkingman.gov
 CITYOFKINGSBURG-CA.GOV,City,Non-Federal Agency,City of Kingsburg,Kingsburg,CA,(blank)
@@ -614,10 +617,11 @@ CITYOFPACIFICWA.GOV,City,Non-Federal Agency,City of Pacific,Pacific,WA,lingraham
 CITYOFPAGEDALEMO.GOV,City,Non-Federal Agency,CITY OF PAGEDALE,PAGEDALE,MO,AHUCKLEBERRY@CITYOFPAGEDALE.ORG
 CITYOFPARISTN.GOV,City,Non-Federal Agency,City of Paris,Paris,TN,(blank)
 CITYOFPARMA-OH.GOV,City,Non-Federal Agency,"City of Parma, Ohio",Parma,OH,(blank)
-CITYOFPASSAICNJ.GOV,City,Non-Federal Agency,City of Passaic,Passaic,NJ,(blank)
+CITYOFPASSAICNJ.GOV,City,Non-Federal Agency,City of Passaic,Passaic,NJ,cpost@cityofpassaicnj.gov
 CITYOFPATASKALAOHIO.GOV,City,Non-Federal Agency,City of Pataskala,Pataskala,OH,(blank)
 CITYOFPATTERSONLA.GOV,City,Non-Federal Agency,City of Patterson,Patterson,LA,(blank)
 CITYOFPEARIDGEAR.GOV,City,Non-Federal Agency,City of Pea Ridge,Pea Ridge,AR,tech.director@cityofpearidge.com
+CITYOFPERRIS.GOV,City,Non-Federal Agency,City of Perris,Perris,CA,itgroup@cityofperris.org
 CITYOFPHOENIX.GOV,City,Non-Federal Agency,City of Phoenix,Phoenix,AZ,(blank)
 CITYOFPIGEONFORGETN.GOV,City,Non-Federal Agency,City of Pigeon Forge,Pigeon Forge,TN,(blank)
 CITYOFPINCONNINGMI.GOV,City,Non-Federal Agency,City of Pinconning,Pinconning,MI,bosworth.jay@gmail.com
@@ -641,6 +645,7 @@ CITYOFSNOQUALMIEWA.GOV,City,Non-Federal Agency,City of Snoqualmie,Snoqualmie,WA,
 CITYOFSOUTHFULTONGA.GOV,City,Non-Federal Agency,City of South Fulton,Atlanta,GA,service.cby@cityofsouthfultonga.gov
 CITYOFSPARTANBURG-SC.GOV,City,Non-Federal Agency,City of Spartanburg,Spartanburg,SC,(blank)
 CITYOFSPENCEROK.GOV,City,Non-Federal Agency,City of Spencer,Spencer,OK,(blank)
+CITYOFSPOONERWI.GOV,City,Non-Federal Agency,City of Spooner,Spooner,WI,(blank)
 CITYOFSTOCKBRIDGE-GA.GOV,City,Non-Federal Agency,City of Stockbridge,Stockbridge,GA,(blank)
 CITYOFTITUSVILLEPA.GOV,City,Non-Federal Agency,City of Titusville Pennsylvania,Titusville,PA,(blank)
 CITYOFTOMBSTONEAZ.GOV,City,Non-Federal Agency,City of Tombstone,Tombstone,AZ,(blank)
@@ -750,6 +755,7 @@ CORALGABLESFL.GOV,City,Non-Federal Agency,City Of Coral Gables,Coral Gables,FL,(
 CORALSPRINGSFL.GOV,City,Non-Federal Agency,City of Coral Springs,Coral Springs,FL,itsecurity@coralsprings.org
 CORBIN-KY.GOV,City,Non-Federal Agency,City of Corbin Kentucky,Corbin,KY,rodney@planetearthpc.com
 CORCORANMN.GOV,City,Non-Federal Agency,City of Corcoran,Corcoran,MN,chris.rickert@cit-net.com
+CORFUNY.GOV,City,Non-Federal Agency,Village of Corfu New York,Corfu,NY,shanemihale@gmail.com
 CORNELIUSOR.GOV,City,Non-Federal Agency,"City of Cornelius, Oregon",Cornelius,OR,security@ci.cornelius.or.us
 CORNINGAR.GOV,City,Non-Federal Agency,City of Corning Arkansas,Corning,AR,(blank)
 CORNWALLNY.GOV,City,Non-Federal Agency,The Town of Cornwall,Cornwall,NY,(blank)
@@ -865,6 +871,7 @@ DICKSONCITY-PA.GOV,City,Non-Federal Agency,Dickson City Borough,Dickson City,PA,
 DIGHTON-MA.GOV,City,Non-Federal Agency,Town of Dighton,Dighton,MA,kbrady@dighton-ma.gov
 DILLONCO.GOV,City,Non-Federal Agency,Town of Dillon,Dillon,CO,caleo@townofdillon.com
 DISCOVERWAUKESHA-WI.GOV,City,Non-Federal Agency,City of Waukesha,Waukesha,WI,gvanness@waukesha-wi.gov
+DODGEVILLEWI.GOV,City,Non-Federal Agency,City of Dodgeville,Dodgeville,WI,dennismckernan@utcwisconsin.com
 DONALDOREGON.GOV,City,Non-Federal Agency,City of Donald ,Donald,OR,(blank)
 DONALDSONVILLE-LA.GOV,City,Non-Federal Agency,City of Donaldsonville,Donaldsonville,LA,lee@visitdonaldsonville.org
 DORAL-FL.GOV,City,Non-Federal Agency,City of Doral IT Department,Doral,FL,sergio.fernandez@cityofdoral.com
@@ -1101,7 +1108,7 @@ FRANKLINNJ.GOV,City,Non-Federal Agency,Township of Franklin,Somerset,NJ,Robert.M
 FRANKLINPA.GOV,City,Non-Federal Agency,City of Franklin,Franklin,PA,(blank)
 FRANKLINTN.GOV,City,Non-Federal Agency,CIty of Franklin,Franklin,TN,(blank)
 FRANKLINWI.GOV,City,Non-Federal Agency,City of Franklin,Franklin,WI,(blank)
-FRANKSTONTX.GOV,City,Non-Federal Agency,City of Frankston,Frankston,TX,rgoodman@frankstontexas.com
+FRANKSTONTX.GOV,City,Non-Federal Agency,City of Frankston,Frankston,TX,dgoodman@frankstontx.gov
 FREDERICKCO.GOV,City,Non-Federal Agency,Town of Frederick,Frederick,CO,(blank)
 FREDERICKMD.GOV,City,Non-Federal Agency,City of Frederick,Frederick,MD,helpdesk@cityoffrederick.com
 FREDERICKSBURGVA.GOV,City,Non-Federal Agency,City of Fredericksburg,Fredericksburg,VA,kgbane@fredericksburgva.gov
@@ -1166,6 +1173,7 @@ GIRARDKANSAS.GOV,City,Non-Federal Agency,"City of Girard, Kansas",Girard,KS,(bla
 GLASTONBURY-CT.GOV,City,Non-Federal Agency,"Town of Glastonbury, CT",Glastonbury,CT,itstaff@glastonbury-ct.gov
 GLASTONBURYCT.GOV,City,Non-Federal Agency,Town of Glastonbury,Glastonbury,CT,itstaff@glastonbury-ct.gov
 GLENBEULAHWI.GOV,City,Non-Federal Agency,Village of Glenbeulah,Glenbeulah,WI,support@pros4technology.com
+GLENCARBONIL.GOV,City,Non-Federal Agency,Village of Glen Carbon,Glen Carbon,IL,cschaller@glen-carbon.il.us
 GLENCOVENY.GOV,City,Non-Federal Agency,City of Glen Cove,Glen Cove,NY,(blank)
 GLENDALE-WI.GOV,City,Non-Federal Agency,"City of Glendale, Wisconsin",Glendale,WI,(blank)
 GLENDALEAZ.GOV,City,Non-Federal Agency,"City of Glendale, Arizona",Glendale,AZ,it_security@glendaleaz.com
@@ -1514,7 +1522,7 @@ KINROSSTOWNSHIP-MI.GOV,City,Non-Federal Agency,Kinross Charter Township,Kinchelo
 KINSTONNC.GOV,City,Non-Federal Agency,City of Kinston,Kinston,NC,(blank)
 KIRKLANDWA.GOV,City,Non-Federal Agency,City of Kirkland,Kirkland,WA,csaunders@kirklandwa.gov
 KISKITOWNSHIP-PA.GOV,City,Non-Federal Agency,Kiskiminetas Township,Apollo,PA,(blank)
-KISSIMMEE.GOV,City,Non-Federal Agency,City of Kissimmee,Kissimmee,FL,jwest@kissimmee.org
+KISSIMMEE.GOV,City,Non-Federal Agency,City of Kissimmee,Kissimmee,FL,jim.west@kissimmee.gov
 KITTERYME.GOV,City,Non-Federal Agency,Town of Kittery Maine,Kittery,ME,(blank)
 KITTYHAWKNC.GOV,City,Non-Federal Agency,Town of Kitty Hawk,Kitty Hawk,NC,angela.vanover@kittyhawktown.net
 KNIGHTDALENC.GOV,City,Non-Federal Agency,Town of Knightdale,Knightdale,NC,phillip.bunton@knightdalenc.gov
@@ -1600,6 +1608,7 @@ LEBANONOHIO.GOV,City,Non-Federal Agency,City of Lebanon,Lebanon,OH,mhawkey@leban
 LEBANONOREGON.GOV,City,Non-Federal Agency,City of Lebanon,Lebanon,OR,helpdesk@ci.lebanon.or.us
 LECLAIREIOWA.GOV,City,Non-Federal Agency,"CITY OF LECLAIRE, IOWA",LECLAIRE,IA,(blank)
 LEEDSALABAMA.GOV,City,Non-Federal Agency,City of Leeds,Leeds,AL,(blank)
+LEELANAUTOWNSHIPMI.GOV,City,Non-Federal Agency,Leelanau Township,Northport,MI,(blank)
 LEESBURGFLORIDA.GOV,City,Non-Federal Agency,City of Leesburg Florida,Leesburg,FL,(blank)
 LEESBURGVA.GOV,City,Non-Federal Agency,"Town of Leesburg, Virginia",Leesburg,VA,(blank)
 LEESVILLELA.GOV,City,Non-Federal Agency,CITY OF LEESVILLE,LEESVILLE,LA,(blank)
@@ -1749,7 +1758,7 @@ MAPLEVALLEYWA.GOV,City,Non-Federal Agency,"City of Maple Valley, Washington",Map
 MAPLEWOODMN.GOV,City,Non-Federal Agency,City of Maplewood,Maplewood,MN,(blank)
 MARANAAZ.GOV,City,Non-Federal Agency,Town of Marana,Marana,AZ,TSInfra@MaranaAz.gov
 MARBLEFALLSTX.GOV,City,Non-Federal Agency,City of Marble Falls,Marble Falls,TX,cmcdonald@marblefallstx.gov
-MARENGOMI.GOV,City,Non-Federal Agency,Marengo Township,Albion,MI,(blank)
+MARENGOMI.GOV,City,Non-Federal Agency,Marengo Township,Albion,MI,security@limecuda.com
 MARIAVILLEME.GOV,City,Non-Federal Agency,TOWN OF MARIAVILLE,MARIAVILLE,ME,abuse@mariavilleme.gov
 MARICOPA-AZ.GOV,City,Non-Federal Agency,City of Maricopa,Maricopa,AZ,(blank)
 MARIETTAGA.GOV,City,Non-Federal Agency,City of Marietta,Marietta,GA,(blank)
@@ -1914,6 +1923,7 @@ MOUNTAINHOUSECA.GOV,City,Non-Federal Agency,Mountain House Community Services Di
 MOUNTAINVIEW.GOV,City,Non-Federal Agency,City of Mountain View,Mountain View,CA,(blank)
 MOUNTAIRYMD.GOV,City,Non-Federal Agency,Town of Mount Airy,Mount Airy,MD,(blank)
 MOUNTCARMELTN.GOV,City,Non-Federal Agency,Town of Mount Carmel,Mount Carmel,TN,tammy.conner@mountcarmeltn.gov
+MOUNTCLEMENS.GOV,City,Non-Federal Agency,City of Mount Clemens,MOUNT CLEMENS,MI,info@cityofmountclemens.com
 MOUNTKISCONY.GOV,City,Non-Federal Agency,Village of Mount Kisco,Mount Kisco,NY,(blank)
 MOUNTPOCONO-PA.GOV,City,Non-Federal Agency,Mount Pocono Borough,Mount Pocono,PA,(blank)
 MOUNTVERNONWA.GOV,City,Non-Federal Agency,City of Mount Vernon,Mount Vernon,WA,scottw@mountvernonwa.gov
@@ -2238,7 +2248,7 @@ PINETOPLAKESIDEAZ.GOV,City,Non-Federal Agency,TOWN OF PINETOP-LAKESIDE,LAKESIDE,
 PINEVILLENC.GOV,City,Non-Federal Agency,Town of Pineville,Pineville,NC,jallred@nucentric.com
 PITTMANCENTERTN.GOV,City,Non-Federal Agency,Town of Pittman Center ,Sevierville,TN,tkwatts@pittmancentertn.gov
 PITTSBORONC.GOV,City,Non-Federal Agency,Town of Pittsboro,Pittsboro,NC,hmeacham@pittsboronc.gov
-PITTSBURGCA.GOV,City,Non-Federal Agency,CITY OF PITTSBURG,PITTSBURG,CA,jkaneria@ci.pittsburg.ca.us
+PITTSBURGCA.GOV,City,Non-Federal Agency,CITY OF PITTSBURG,PITTSBURG,CA,jkaneria@pittsburgca.gov
 PITTSBURGHPA.GOV,City,Non-Federal Agency,City of Pittsburgh,Pittsburgh,PA,(blank)
 PITTSFIELD-MI.GOV,City,Non-Federal Agency,Pittsfield Charter Township,Ann Arbor,MI,infosys@pittsfield-mi.gov
 PITTSFIELDNH.GOV,City,Non-Federal Agency,Town of Pittsfield,Pittsfield,NH,cmarston@pittsfieldnh.gov
@@ -2388,6 +2398,7 @@ RIDGEFIELDCT.GOV,City,Non-Federal Agency,Town of Ridgefield,Ridgefield,CT,itsupp
 RIDGEFIELDNJ.GOV,City,Non-Federal Agency,The Borough of Ridgefield,Ridgefield,NJ,(blank)
 RIDGELANDSC.GOV,City,Non-Federal Agency,Town of Ridgeland,Ridgeland,SC,support@hazeldigitalmedia.com
 RIORANCHONM.GOV,City,Non-Federal Agency,City of Rio Rancho,Rio Rancho,NM,(blank)
+RIPON-WI.GOV,City,Non-Federal Agency,City of Ripon,Ripon,WI,helpdesk@loyality.com
 RIVERDALEGA.GOV,City,Non-Federal Agency,City of Riverdale,Riverdale,GA,(blank)
 RIVERDALENJ.GOV,City,Non-Federal Agency,Borough of Riverdale,Riverdale,NJ,(blank)
 RIVERDALEPARKMD.GOV,City,Non-Federal Agency,Town of Riverdale Park,Riverdale,MD,(blank)
@@ -2437,6 +2448,7 @@ ROSENBERGTX.GOV,City,Non-Federal Agency,City of Rosenberg,Rosenberg,TX,(blank)
 ROSEVILLE-MI.GOV,City,Non-Federal Agency,City of Roseville,Roseville,MI,caustin@roseville-mi.gov
 ROSLYNNY.GOV,City,Non-Federal Agency,The Village of Roslyn,Roslyn,NY,(blank)
 ROSSLYNFARMSPA.GOV,City,Non-Federal Agency,Borough of Rosslyn Farms,Carnegie,PA,RosslynFarms.Secretary@gmail.com
+ROSSVILLEGA.GOV,City,Non-Federal Agency,"City of Rossville, GA",Rossville,GA,thill.fofr@gmail.com
 ROSWELL-NM.GOV,City,Non-Federal Agency,City of Roswell,Roswell,NM,(blank)
 ROUNDLAKEBEACHIL.GOV,City,Non-Federal Agency,Village of Round Lake Beach,Round Lake Beach,IL,(blank)
 ROUNDLAKEIL.GOV,City,Non-Federal Agency,Village of Round Lake,Round Lake,IL,abuse@roundlakeil.gov
@@ -2511,6 +2523,7 @@ SBVT.GOV,City,Non-Federal Agency,City of South Burlington VT,South Burlington,VT
 SCHAUMBURGIL.GOV,City,Non-Federal Agency,Village of Schaumburg,Schaumburg,IL,itnotify@schaumburg.com
 SCHENECTADYNY.GOV,City,Non-Federal Agency,City of Schenectady,Schenectady,NY,cosits4@gmail.com
 SCHERTZ-TX.GOV,City,Non-Federal Agency,City of Schertz,Schertz,TX,it_dept@schertz.com
+SCHOOLCRAFTTOWNSHIPMI.GOV,City,Non-Federal Agency,Schoolcraft Township,Vicksburg,MI,kps@shumakergroup.com
 SCIOOREGON.GOV,City,Non-Federal Agency,City of Scio,Scio,OR,it@scio.city
 SCIOTOTOWNSHIP-OH.GOV,City,Non-Federal Agency,Scioto Township,Commercial Point,OH,(blank)
 SCITUATEMA.GOV,City,Non-Federal Agency,Town of Scituate,Scituate,MA,mminchello@scituatema.gov
@@ -2627,6 +2640,7 @@ SOUTHTUCSONAZ.GOV,City,Non-Federal Agency,City of South Tucson,South Tucson,AZ,l
 SOUTHWINDSOR-CT.GOV,City,Non-Federal Agency,Town of South Windsor,South Windsor,CT,(blank)
 SPARTANJ.GOV,City,Non-Federal Agency,Township of Sparta,Sparta,NJ,Michael.Dempsey@spartanj.org
 SPARTATN.GOV,City,Non-Federal Agency,City of Sparta,Sparta,TN,(blank)
+SPEAKERTWPMI.GOV,City,Non-Federal Agency,Speaker Township,Melvin,MI,support@itright.com
 SPEEDWAYIN.GOV,City,Non-Federal Agency,Town of Speedway,Speedway,IN,(blank)
 SPENCERMA.GOV,City,Non-Federal Agency,Town of Spencer,Spencer,MA,(blank)
 SPENCERNC.GOV,City,Non-Federal Agency,Town of Spencer,Spencer,NC,(blank)
@@ -2685,6 +2699,7 @@ STMICHAELMN.GOV,City,Non-Federal Agency,City of St. Michael,St. Michael,MN,techn
 STMICHAELSMD.GOV,City,Non-Federal Agency,"Town of St. Michaels, Maryland",St. Michaels,MD,(blank)
 STOCKBRIDGE-MA.GOV,City,Non-Federal Agency,Town of Stockbridge,Stockbridge,MA,jshannon@net-engineering.com
 STOCKBRIDGEGA.GOV,City,Non-Federal Agency,City of Stockbridge,Stockbridge,GA,(blank)
+STOCKBRIDGEVT.GOV,City,Non-Federal Agency,Town of Stockbridge,Stockbridge,VT,stockbridgevtzoning@gmail.com
 STOCKTONCA.GOV,City,Non-Federal Agency,City of Stockton,Stockton,CA,(blank)
 STONEHAM-MA.GOV,City,Non-Federal Agency,Town of Stoneham,Stoneham,MA,secure@stoneham-ma.gov
 STONINGTON-CT.GOV,City,Non-Federal Agency,Town of Stonington,Stonington,CT,(blank)
@@ -2809,10 +2824,11 @@ TOWNOFGOLDENMEADOW-LA.GOV,City,Non-Federal Agency,Town of Golden Meadow,Golden M
 TOWNOFGRANVILLEWV.GOV,City,Non-Federal Agency,Town of Granville,Granville,WV,(blank)
 TOWNOFHALFMOON-NY.GOV,City,Non-Federal Agency,Town of Halfmoon,Halfmoon,NY,admin@townofhalfmoon.org
 TOWNOFHAMILTONNY.GOV,City,Non-Federal Agency,Town of Hamilton,Hamilton,NY,security@townofhamiltonny.org
-TOWNOFHAVERHILL-FL.GOV,City,Non-Federal Agency,Town of Haverhill,Haverhill,FL,(blank)
+TOWNOFHAVERHILL-FL.GOV,City,Non-Federal Agency,Town of Haverhill,Haverhill,FL,jrutan@townofhaverhill-fl.gov
 TOWNOFHAYDENAZ.GOV,City,Non-Federal Agency,Town of Hayden,Hayden,AZ,(blank)
 TOWNOFHOMECROFTIN.GOV,City,Non-Federal Agency,Town of Homecroft,Indianapolis,IN,(blank)
 TOWNOFHULBERTOK.GOV,City,Non-Federal Agency,Town of Hulbert,Hulbert,OK,tmbrave@gmail.com
+TOWNOFHUMENY.GOV,City,Non-Federal Agency,Town of Hume,Fillmore,NY,humetownclerk@gmail.com
 TOWNOFHURTVA.GOV,City,Non-Federal Agency,TOWN OF HURT,HURT,VA,(blank)
 TOWNOFISLIP-NY.GOV,City,Non-Federal Agency,Town of Islip,Islip,NY,(blank)
 TOWNOFJAYNY.GOV,City,Non-Federal Agency,Town of Jay,Au Sable Forks,NY,informationsystems@essexcountyny.gov
@@ -2935,6 +2951,7 @@ VERNON-CT.GOV,City,Non-Federal Agency,Town of Vernon Connecticut,Vernon,CT,(blan
 VERNONIA-OR.GOV,City,Non-Federal Agency,City of Vernonia,Vernonia,OR,(blank)
 VERNONTWP-PA.GOV,City,Non-Federal Agency,VERNON TOWNSHIP,Meadville,PA,(blank)
 VERNONTX.GOV,City,Non-Federal Agency,City of Vernon,Vernon,TX,(blank)
+VERNONVT.GOV,City,Non-Federal Agency,Town of Vernon,Vernon,VT,security@vernonvt.org
 VERONANJ.GOV,City,Non-Federal Agency,Township of Verona,Verona,NJ,mmccormack@veronanj.org
 VERONAWI.GOV,City,Non-Federal Agency,City of Verona,Verona,WI,(blank)
 VESTALNY.GOV,City,Non-Federal Agency,Town of Vestal,Vestal,NY,dwilliams@vestalny.com
@@ -2945,6 +2962,7 @@ VIDALIAGA.GOV,City,Non-Federal Agency,CITY OF VIDALIA,VIDALIA,GA,jalexander@tota
 VIENNAVA.GOV,City,Non-Federal Agency,TOWN OF VIENNA (va) GOVERNMENT,VIENNA,VA,(blank)
 VILLAGEOFBABYLONNY.GOV,City,Non-Federal Agency,Village of Babylon,Babylon,NY,(blank)
 VILLAGEOFCAMILLUS-NY.GOV,City,Non-Federal Agency,VILLAGE OF CAMILLUS,CAMILLUS,NY,(blank)
+VILLAGEOFCARBONHILL-IL.GOV,City,Non-Federal Agency,Village of Carbon Hill,Carbon Hill,IL,itadministrator@villageofcarbonhill-il.gov
 VILLAGEOFDUNLAP-IL.GOV,City,Non-Federal Agency,Village of Dunlap,Dunlap,IL,(blank)
 VILLAGEOFGOSHEN-NY.GOV,City,Non-Federal Agency,Village of Goshen,Goshen,NY,ilan@progressiveelement.com
 VILLAGEOFGOUVERNEURNY.GOV,City,Non-Federal Agency,Village of Gouverneur,Gouverneur,NY,(blank)
@@ -3043,6 +3061,7 @@ WEBSTERGROVESMO.GOV,City,Non-Federal Agency,City of Webster Groves,Webster Grove
 WEBSTERNY.GOV,City,Non-Federal Agency,Town of Webster,Webster,NY,security@ci.webster.ny.us
 WEBSTERNYTODAY.GOV,City,Non-Federal Agency,Town of Webster,Webster,NY,ns-security@ci.webster.ny.us
 WEEHAWKENNJ.GOV,City,Non-Federal Agency,Township of Weehawken,Weehawken,NJ,chablitz@police.weehawkennj.gov
+WEHO.GOV,City,Non-Federal Agency,City of West Hollywood,West Hollywood,CA,domain-security@weho.org
 WELAKA-FL.GOV,City,Non-Federal Agency,Town of Welaka,Welaka,FL,will.walsh@walshlogic.com
 WELLESLEYMA.GOV,City,Non-Federal Agency,Town of Wellesley,Wellesley,MA,(blank)
 WELLFLEET-MA.GOV,City,Non-Federal Agency,Town of Wellfleet,Wellfleet,MA,courtney.butler@wellfleet-ma.gov
@@ -3217,6 +3236,9 @@ ANSONCOUNTYNC.GOV,County,Non-Federal Agency,County of Anson,Wadesboro,NC,chris.j
 APACHECOUNTYAZ.GOV,County,Non-Federal Agency,"Apache County, Arizona",Saint Johns,AZ,helpdesk@co.apache.az.us
 APPOMATTOXCOUNTYVA.GOV,County,Non-Federal Agency,Appomattox County,Appomattox,VA,(blank)
 ARANSASCOUNTYTX.GOV,County,Non-Federal Agency,"Aransas County, State of Texas",Rockport,TX,abuse@aransascountytx.gov
+ARAPAHOECO.GOV,County,Non-Federal Agency,Arapahoe County,Littleton,CO,itsecurity@arpahoegov.com
+ARAPAHOESHERIFF.GOV,County,Non-Federal Agency,Arapahoe Conty,Littleton,CO,itsecurity@arapahoegov.com
+ARAPAHOEVOTES.GOV,County,Non-Federal Agency,Arapahoe County,Littleton,CO,itsecurity@arapahoegov.com
 ARENACCOUNTYMI.GOV,County,Non-Federal Agency,Arenac County Commissioners Office,Standish,MI,(blank)
 ARLINGTONCOUNTYVA.GOV,County,Non-Federal Agency,Arlington County Government,Arlington,VA,ddomain@arlingtonva.us
 ARLINGTONVA.GOV,County,Non-Federal Agency,Arlington County Government,Arlington,VA,ciso@arlingtonva.us
@@ -3247,7 +3269,7 @@ BEAVERCOUNTYPA.GOV,County,Non-Federal Agency,Beaver County Information Technolog
 BEDFORDCOUNTYTN.GOV,County,Non-Federal Agency,Bedford County Government,Shelbyville,TN,alex.arroyo@bedfordcountytn.gov
 BEDFORDCOUNTYVA.GOV,County,Non-Federal Agency,Bedford County Government,Bedford,VA,infosys@bedfordcountyva.gov
 BENHILLCOUNTY-GA.GOV,County,Non-Federal Agency,Ben Hill County,Fitzgerald,GA,(blank)
-BENTONCOUNTYAR.GOV,County,Non-Federal Agency,Benton County Government,Bentonville,AR,(blank)
+BENTONCOUNTYAR.GOV,County,Non-Federal Agency,Benton County Government,Bentonville,AR,ITCyber@bentoncountyar.gov
 BENTONCOUNTYIA.GOV,County,Non-Federal Agency,Benton County Iowa,Vinton,IA,security@co.benton.ia.us
 BENTONCOUNTYMS.GOV,County,Non-Federal Agency,Benton County Board of Supervisors,Ashland,MS,rickypipkin@yahoo.com
 BENTONCOUNTYTN.GOV,County,Non-Federal Agency,"Benton County, Tennessee",Camden,TN,it@bentoncountytn.gov
@@ -3511,6 +3533,7 @@ FENTRESSCOUNTYTN.GOV,County,Non-Federal Agency,Fentress County Emergency Managem
 FILLMORECOUNTYNE.GOV,County,Non-Federal Agency,Fillmore County,Geneva,NE,amy.nelson@fillmore.nacone.org
 FLAGLERCOUNTY.GOV,County,Non-Federal Agency,Flagler County Board of County Commissioners,Bunnell,FL,itsec@flaglercounty.org
 FLAGLERELECTIONS.GOV,County,Non-Federal Agency,Flagler County Supervisor of Elections,BUNNELL,FL,info@flaglerelections.com
+FLORENCECOUNTYWI.GOV,County,Non-Federal Agency,FLORENCE COUNTY,FLORENCE,WI,jsteber@co.florence.wi.us
 FLOYDCOUNTYGA.GOV,County,Non-Federal Agency,Floyd County Government,Rome,GA,holcombl@floydcountyga.org
 FNSB.GOV,County,Non-Federal Agency,Fairbanks North Star Borough,Fairbanks,AK,security@fnsb.us
 FORSYTHCOUNTYNC.GOV,County,Non-Federal Agency,Forsyth County,Winston Salem,NC,aegis@forsyth.cc
@@ -3532,11 +3555,13 @@ FRESNOCOUNTYCA.GOV,County,Non-Federal Agency,County of Fresno,Fresno,CA,(blank)
 FRESNOCOUNTYJOBS.GOV,County,Non-Federal Agency,County of Fresno,Fresno,CA,(blank)
 FULTONCOUNTYAR.GOV,County,Non-Federal Agency,Fulton County Judge's Office,Salem,AR,markm@bjmweb.com
 FULTONCOUNTYGA.GOV,County,Non-Federal Agency,Fulton County Government,Atlanta,GA,terrence.slaton@fultoncountyga.gov
+FULTONCOUNTYIL.GOV,County,Non-Federal Agency,Fulton County Illinois,Lewistown,IL,(blank)
 FULTONCOUNTYNY.GOV,County,Non-Federal Agency,County of Fulton,Johnstown,NY,(blank)
 GADSDENCOUNTYFL.GOV,County,Non-Federal Agency,Gadsden County BOCC,Quincy,FL,(blank)
 GALVESTONCOUNTYTX.GOV,County,Non-Federal Agency,County of Galveston,Galveston,TX,IT-InfrastructureSupport@co.galveston.tx.us
 GARFIELDCOUNTY-CO.GOV,County,Non-Federal Agency,Garfield County,Glenwood Springs,CO,(blank)
 GARLANDCOUNTYAR.GOV,County,Non-Federal Agency,Garland County,Hot Springs,AR,(blank)
+GARRETTCOUNTYMD.GOV,County,Non-Federal Agency,Garrett County Commissioners,Oakland,MD,itstaff@garrettcounty.org
 GATESCOUNTYNC.GOV,County,Non-Federal Agency,County of Gates,Gatesville,NC,domainsecuritypoc@gatescountync.gov
 GCSO.GOV,County,Non-Federal Agency,"Guthrie County, Iowa",Guthrie Center,IA,abuse@guthriecounty.gov
 GENESEECOUNTYMI.GOV,County,Non-Federal Agency,Genesee County,Flint,MI,aaronj@geneseecountymi.gov
@@ -3582,6 +3607,7 @@ GREENWOODCOUNTY-SC.GOV,County,Non-Federal Agency,Greenwood County,Greenwood,SC,(
 GREENWOODSC.GOV,County,Non-Federal Agency,Greenwood County,Greenwood,SC,ssprouse@greenwoodsc.gov
 GRIGGSCOUNTYND.GOV,County,Non-Federal Agency,State of ND,Bismarck,ND,itsecur@nd.gov
 GRIMESCOUNTYTEXAS.GOV,County,Non-Federal Agency,Grimes County,Anderson,TX,(blank)
+GRUNDYCOUNTYIL.GOV,County,Non-Federal Agency,Grundy County IL,Morris,IL,securityreports@grundyco.org
 GRUNDYCOUNTYIOWA.GOV,County,Non-Federal Agency,Grundy County,Grundy Center,IA,security@grundycountyiowa.gov
 GTCOUNTYMI.GOV,County,Non-Federal Agency,Grand Traverse County,Traverse City,MI,support@gtcountymi.gov
 GUERNSEYCOUNTY.GOV,County,Non-Federal Agency,Guernsey County Local Government,Cambridge,OH,kmathews@guernseycounty.org
@@ -3805,12 +3831,14 @@ MASONCOUNTYWA.GOV,County,Non-Federal Agency,Mason County,Shelton,WA,ITdept@CO.MA
 MASONCOUNTYWV.GOV,County,Non-Federal Agency,Mason County Commission,Point Pleasant,WV,support@thevalleylist.us
 MASSACCOUNTYIL.GOV,County,Non-Federal Agency,Massac County,Metropolis,IL,(blank)
 MATHEWSCOUNTYVA.GOV,County,Non-Federal Agency,County of Mathews,Mathews,VA,hturner@mathewscountyva.gov
+MATSU.GOV,County,Non-Federal Agency,Matanuska-Susitna Borough,Palmer,AK,(blank)
 MAUICOUNTY-HI.GOV,County,Non-Federal Agency,County of Maui,Wailuku,HI,(blank)
 MAUICOUNTY.GOV,County,Non-Federal Agency,County of Maui,Wailuku,HI,karen.sherman@co.maui.hi.us
 MAURYCOUNTY-TN.GOV,County,Non-Federal Agency,Maury County Government,Columbia,TN,(blank)
 MCCRACKENCOUNTYKY.GOV,County,Non-Federal Agency,McCracken County Fiscal Court,Paducah,KY,security@mccrackenky.com
 MCCURTAINEMS.GOV,County,Non-Federal Agency,McCurtain County EMS,Idabel,OK,(blank)
 MCDONALDCOUNTYMO.GOV,County,Non-Federal Agency,"County of McDonald, Missouri",Pineville,MO,gregg.sweeten@mcdonaldcountymo.gov
+MCDOWELLCOUNTYNCBOE.GOV,County,Non-Federal Agency,McDowell County Board of Elections,Marion,NC,rayburn.davis@mcdowellgov.com
 MCHENRYCOUNTYIL.GOV,County,Non-Federal Agency,McHenry County Government Center,Woodstock,IL,(blank)
 MCHENRYCOUNTYILLINOIS.GOV,County,Non-Federal Agency,McHenry County Government Center,Woodstock,IL,(blank)
 MCINTOSHCOUNTY-GA.GOV,County,Non-Federal Agency,McIntosh County Booard of Commssioners,Darien,GA,(blank)
@@ -4166,6 +4194,7 @@ UNIONCOUNTYOR.GOV,County,Non-Federal Agency,Union County,La Grande,OR,noc@union-
 UNIONCOUNTYTN.GOV,County,Non-Federal Agency,Union County TN,Maynardville,TN,(blank)
 UTAHCOUNTY.GOV,County,Non-Federal Agency,Utah County Government,Provo,UT,(blank)
 VALLEYCOUNTYMT.GOV,County,Non-Federal Agency,Valley County Courthouse,Glasgow,MT,(blank)
+VALLEYCOUNTYNE.GOV,County,Non-Federal Agency,Valley County Nebraska,Ord,NE,support@appliedconnective.com
 VANBURENCOUNTY-MI.GOV,County,Non-Federal Agency,Van Buren County,Paw Paw,MI,postmaster@vbco.org
 VANBURENCOUNTYIA.GOV,County,Non-Federal Agency,Van Buren County Iowa,Keosauqua,IA,(blank)
 VANBURENCOUNTYMI.GOV,County,Non-Federal Agency,Information Services,Paw Paw,MI,postmaster@vbco.org
@@ -4176,6 +4205,7 @@ VINTONCOUNTYOHIO.GOV,County,Non-Federal Agency,Vinton County Commissioner's Offi
 VOTEBREVARD.GOV,County,Non-Federal Agency,Brevard County Supervisor of Elections,Melbourne,FL,security@votebrevard.com
 VOTECITRUS.GOV,County,Non-Federal Agency,Citrus County Supervisor of Elections,Crystal River,FL,bryce.hale@votecitrus.com
 VOTEDENTON.GOV,County,Non-Federal Agency,Denton County Elections Administration,Denton,TX,security@dentoncounty.gov
+VOTEFRANKLINFL.GOV,County,Non-Federal Agency,Franklin County Supervisor of Elections,APALACHICOLA,FL,helpdesk@inspired-tech.net
 VOTEGULF.GOV,County,Non-Federal Agency,Gulf County Supervisor of Elections,Port St. Joe,FL,jhanlon@votegulf.com
 VOTEHAMILTONCOUNTYOHIO.GOV,County,Non-Federal Agency,Hamilton County Board of Elections,Norwood,OH,hcboe.cyber@boe.hamiltoncountyohio.gov
 VOTEHILLSBOROUGH.GOV,County,Non-Federal Agency,Hillsborough County Supervisor of Elections,Tampa,FL,(blank)
@@ -4461,6 +4491,7 @@ DOEAL.GOV,Federal Agency - Executive,Department of Energy,NNSA,Albuquerque,NM,Co
 EIA.GOV,Federal Agency - Executive,Department of Energy,Energy Information Administration,Washington,DC,marc.cree@eia.gov
 ENERGY.GOV,Federal Agency - Executive,Department of Energy,"US Department of Energy, Office of the CIO",Washington,DC,CIRC@JC3.DOE.GOV
 ENERGYCODES.GOV,Federal Agency - Executive,Department of Energy,Department of Energy Bulding Energy Codes Program,Richland,WA,CIRC@JC3.DOE.GOV
+ENERGYCOMMUNITIES.GOV,Federal Agency - Executive,Department of Energy,"US Department of Energy, Office of the CIO",Washington,DC,CIRC@JC3.DOE.GOV
 ENERGYSAVER.GOV,Federal Agency - Executive,Department of Energy,Office of Energy Efficiency and Renewable Energy,Washington,DC,CIRC@JC3.DOE.GOV
 ENERGYSAVERS.GOV,Federal Agency - Executive,Department of Energy,Office of Energy Efficiency and Renewable Energy,Washington,DC,CIRC@JC3.DOE.GOV
 FNAL.GOV,Federal Agency - Executive,Department of Energy,Fermi National Accelerator Laboratory,Batavia,IL,security@fnal.gov
@@ -4486,6 +4517,7 @@ NUCLEAR.GOV,Federal Agency - Executive,Department of Energy,US Department of Ene
 ORAU.GOV,Federal Agency - Executive,Department of Energy,ORAU,Oak Ridge,TN,CIRC@JC3.DOE.GOV
 ORNL.GOV,Federal Agency - Executive,Department of Energy,Oak Ridge National Laboratory,Oak Ridge,TN,security@ornl.gov
 OSTI.GOV,Federal Agency - Executive,Department of Energy,OSTI,Oak Ridge,TN,security@osti.gov
+PCAST.GOV,Federal Agency - Executive,Department of Energy,U.S. Department of Energy,Washington,DC,CIRC@JC3.DOE.GOV
 PNL.GOV,Federal Agency - Executive,Department of Energy,Pacific Northwest National Laboratory,Richland,WA,CIRC@JC3.DOE.GOV
 PNNL.GOV,Federal Agency - Executive,Department of Energy,Pacific Northwest National Laboratory,Richland,WA,CIRC@JC3.DOE.GOV
 PPPL.GOV,Federal Agency - Executive,Department of Energy,Princeton Plasma Physics Lab,Princeton,NJ,security@pppl.gov
@@ -4642,6 +4674,7 @@ LISTO.GOV,Federal Agency - Executive,Department of Homeland Security,Office of P
 NIC.GOV,Federal Agency - Executive,Department of Homeland Security,Cybersecurity and Infrastructure Security Agency,Arlington,VA,vulnerability.disclosure.prog@hq.dhs.gov
 NIEM.GOV,Federal Agency - Executive,Department of Homeland Security,"Department of Homeland Security, Office of the Chief Information Officer",Washington,DC,IS2OSecurity@hq.dhs.gov
 NMSC.GOV,Federal Agency - Executive,Department of Homeland Security,National Marine Center,St Augustine,FL,bertram.dobrie@cbp.dhs.gov
+POWER2PREVENT.GOV,Federal Agency - Executive,Department of Homeland Security,Headquarters,Washington,DC,is2osecurity@hq.dhs.gov
 READY.GOV,Federal Agency - Executive,Department of Homeland Security,Office of Public Affairs,Washington,DC,fema-soc@fema.dhs.gov
 READYBUSINESS.GOV,Federal Agency - Executive,Department of Homeland Security,FEMA,Washington,DC,fema-soc@fema.dhs.gov
 SAFETYACT.GOV,Federal Agency - Executive,Department of Homeland Security,Science and Technology,Washington,DC,malik.locket@st.dhs.gov
@@ -5123,7 +5156,6 @@ FAPIIS.GOV,Federal Agency - Executive,General Services Administration,"GSA, IQ, 
 FBF.GOV,Federal Agency - Executive,General Services Administration,"GSA, IQ-CAP",Washington,DC,gsa-vulnerability-reports@gsa.gov
 FBO.GOV,Federal Agency - Executive,General Services Administration,"GSA, IC, Acquisition",Arlington,VA,gsa-vulnerability-reports@gsa.gov
 FDMS.GOV,Federal Agency - Executive,General Services Administration,"GSA, IQ, eRulemaking",Washington,DC,gsa-vulnerability-reports@gsa.gov
-FEDBIZOPPS.GOV,Federal Agency - Executive,General Services Administration,"GSA, IC, OGP Web Portfolio",Arlington,VA,gsa-vulnerability-reports@gsa.gov
 FEDIDCARD.GOV,Federal Agency - Executive,General Services Administration,"GSA, IQ, CAT",Washington,DC,gsa-vulnerability-reports@gsa.gov
 FEDINFO.GOV,Federal Agency - Executive,General Services Administration,"GSA, TTS",Washington,DC,gsa-vulnerability-reports@gsa.gov
 FEDRAMP.GOV,Federal Agency - Executive,General Services Administration,"GSA, TTS",Washington,DC,gsa-vulnerability-reports@gsa.gov
@@ -5314,7 +5346,7 @@ PBRB.GOV,Federal Agency - Executive,Public Buildings Reform Board,General Servic
 RRB.GOV,Federal Agency - Executive,Railroad Retirement Board,Bureau of Information Services,Chicago,IL,security@rrb.gov
 INVESTOR.GOV,Federal Agency - Executive,Securities and Exchange Commission,Network Operations Branch,Washington,DC,security@sec.gov
 SEC.GOV,Federal Agency - Executive,Securities and Exchange Commission,Network Operations Branch,Washington,DC,security@sec.gov
-SSS.GOV,Federal Agency - Executive,Selective Service System,Selective Service System,Arlington,VA,itsupport@sss.gov
+SSS.GOV,Federal Agency - Executive,Selective Service System,Selective Service System,Arlington,VA,soc@sss.gov
 BUSINESS.GOV,Federal Agency - Executive,Small Business Administration,U.S. Small Business Administration,Washington,DC,CISO@sba.gov
 NWBC.GOV,Federal Agency - Executive,Small Business Administration,U.S. Small Business Administration,Washington,DC,CISO@sba.gov
 SBA.GOV,Federal Agency - Executive,Small Business Administration,U.S. Small Business Administration,Washington,DC,CISO@sba.gov
@@ -5433,7 +5465,7 @@ PACER.GOV,Federal Agency - Judicial,U.S. Courts,Administrative Office U.S. Court
 USBANKRUPTCY.GOV,Federal Agency - Judicial,U.S. Courts,Administrative Office U.S. Courts,Washington,DC,(blank)
 USC.GOV,Federal Agency - Judicial,U.S. Courts,U.S. Courts,Washington,DC,(blank)
 USCAVC.GOV,Federal Agency - Judicial,U.S. Courts,US Court of Appeals for Veterans Claims,Washington,DC,(blank)
-USCOURTS.GOV,Federal Agency - Judicial,U.S. Courts,U.S. Courts,Washington,DC,(blank)
+USCOURTS.GOV,Federal Agency - Judicial,U.S. Courts,U.S. Courts,Washington,DC,security@uscourts.gov
 USPROBATION.GOV,Federal Agency - Judicial,U.S. Courts,Administrative Office U.S. Courts,Washington,DC,(blank)
 USSC.GOV,Federal Agency - Judicial,U.S. Courts,US Sentencing Commission,Washington,DC,(blank)
 USTAXCOURT.GOV,Federal Agency - Judicial,U.S. Courts,United States Tax Court,Washington,DC,(blank)
@@ -5551,7 +5583,7 @@ AMERICA250.GOV,Federal Agency - Legislative,U.S. Semiquincentennial Commission,U
 USA250.GOV,Federal Agency - Legislative,U.S. Semiquincentennial Commission,United States Semiquincentennial Commission,Washington D.C.,DC,shommel@america250.org
 USSEMIQUINCENTENNIAL.GOV,Federal Agency - Legislative,U.S. Semiquincentennial Commission,United States Semiquincentennial Commission,Washington D.C.,DC,shommel@america250.org
 USCC.GOV,Federal Agency - Legislative,U.S.-China Economic and Security Review Commission,U.S. - China Economic and Security Review Commission,Washington,DC,(blank)
-SEN.GOV,Federal Agency - Legislative,United States Senate,US Senate,Washington,DC,(blank)
+SEN.GOV,Federal Agency - Legislative,United States Senate,US Senate,Washington,DC,saanoc2@saa.senate.gov
 SENATE.GOV,Federal Agency - Legislative,United States Senate,US Senate,Washington,DC,saanoc2@saa.senate.gov
 WHDPC.GOV,Federal Agency - Legislative,Western Hemisphere Drug Policy Commission,Western Hemisphere Drug Policy Commission,"Washington,",MD,mary.speck@whdpc.gov
 ACCESSOH.GOV,Independent Intrastate Agency,Non-Federal Agency,ACCESS Council,Boardman,OH,access_admin@access-k12.org
@@ -5578,7 +5610,7 @@ DETCOG.GOV,Independent Intrastate Agency,Non-Federal Agency,Deep East Texas Coun
 ELBURNFIRE.GOV,Independent Intrastate Agency,Non-Federal Agency,Elburn & Countryside Fire Protection District,Elburn,IL,info@ecfpd.com
 ELECTIONSSHELBYTN.GOV,Independent Intrastate Agency,Non-Federal Agency,Shelby County Election Commission,Memphis,TN,joe.young@shelbycountytn.gov
 GLACIERVIEWFIRE.GOV,Independent Intrastate Agency,Non-Federal Agency,Glacier View Fire Protection District,Livermore,CO,(blank)
-HRPDCVA.GOV,Independent Intrastate Agency,Non-Federal Agency,Hampton Roads Planning District Commission,Chesapeake,VA,(blank)
+HRPDCVA.GOV,Independent Intrastate Agency,Non-Federal Agency,Hampton Roads Planning District Commission,Chesapeake,VA,serversecurity@insercorp.com
 HUDSONREGIONAL.GOV,Independent Intrastate Agency,Non-Federal Agency,Hudson Regional Health Commission,Secaucus,NJ,itsquad@hudsonregionalhealth.org
 HVCOKSVOTE.GOV,Independent Intrastate Agency,Non-Federal Agency,Harvey County Clerk,Newton,KS,lheim@harveycounty.com
 IL12THCOURT.GOV,Independent Intrastate Agency,Non-Federal Agency,Illinois 12th Circuit Court,Joliet,IL,support@willcountyillinois.com
@@ -6094,7 +6126,7 @@ COURTSWV.GOV,State,Non-Federal Agency,West Virginia Supreme Court of Appeals,Cha
 COVERME.GOV,State,Non-Federal Agency,State of Maine Office of Information Technology,Augusta,ME,Chad.Perkins@maine.gov
 COWORKFORCE.GOV,State,Non-Federal Agency,Colorado Dept Labor and Employement,Denver,CO,(blank)
 CSIMT.GOV,State,Non-Federal Agency,"Montana Office of the Commissioner of Securities and Insurance, Montana State Auditor",Helena,MT,(blank)
-CT.GOV,State,Non-Federal Agency,State of CT/Department of Administrative Services,Hartford,CT, 
+CT.GOV,State,Non-Federal Agency,State of CT/Department of Administrative Services,Hartford,CT,
 CTALERT.GOV,State,Non-Federal Agency,State of Connecticut Department of Emergency Services and Public Protection,Middletown,CT,(blank)
 CTBROWNFIELDS.GOV,State,Non-Federal Agency,State of Connecticut Dept. of Economic & Community Development,Hartford,CT,(blank)
 CTGROWN.GOV,State,Non-Federal Agency,CT Department of Agriculture,Hartford,CT,(blank)
@@ -6278,14 +6310,14 @@ ILLINOISCOURTS.GOV,State,Non-Federal Agency,Administrative Office of the Illinoi
 ILLINOISRETIREMENT.GOV,State,Non-Federal Agency,Illinois State Treasurer's Office,Springfield,IL,JDaniels@illinoistreasurer.gov
 ILLINOISTREASURER.GOV,State,Non-Federal Agency,Illinois State Treasurer's Office,Springfield,IL,(blank)
 ILSOS.GOV,State,Non-Federal Agency,Illinois Secretary of State,Springfield,IL,SecurityAdministrator@ilsos.net
-IN.GOV,State,Non-Federal Agency,State of Indiana,Indianapolis,IN,mjohnson@iot.in.gov
+IN.GOV,State,Non-Federal Agency,State of Indiana,Indianapolis,IN,ewinblad@iot.in.gov
 INCOURTS.GOV,State,Non-Federal Agency,Indiana Office of Technology,Indianapolis,IN,(blank)
-INDIANA.GOV,State,Non-Federal Agency,Indiana Interactive,Indianapolis,IN,mjohnson@iot.in.gov
+INDIANA.GOV,State,Non-Federal Agency,Indiana Interactive,Indianapolis,IN,ewinblad@iot.in.gov
 INDIANAUNCLAIMED.GOV,State,Non-Federal Agency,Indiana Office of the Attorney General,Indianapolis,IN,(blank)
 INNOCENCECOMMISSION-NC.GOV,State,Non-Federal Agency,The North Carolina Innocence Inquiry Commission,Raleigh,NC,(blank)
 INNOVATEOHIO.GOV,State,Non-Federal Agency,State of Ohio,Columbus,OH,domain.manager@das.ohio.gov
 INVESTINIOWA.GOV,State,Non-Federal Agency,Office of the Chief Information Officer,Des Moines,IA,soc@iowa.gov
-IOWA.GOV,State,Non-Federal Agency,State of Iowa - OCIO,Des Moines,IA,(blank)
+IOWA.GOV,State,Non-Federal Agency,State of Iowa - OCIO,Des Moines,IA,soc@iowa.gov
 IOWAAGING.GOV,State,Non-Federal Agency,State of Iowa - OCIO,Des Moines,IA,soc@iowa.gov
 IOWAAGRICULTURE.GOV,State,Non-Federal Agency,State of Iowa - OCIO,Des Moines,IA,soc@iowa.gov
 IOWAATTORNEYGENERAL.GOV,State,Non-Federal Agency,State of Iowa - OCIO,Des Moines,IA,soc@iowa.gov
@@ -6449,8 +6481,8 @@ MYFLORIDAHOUSE.GOV,State,Non-Federal Agency,The Florida House of Representatives
 MYFLORIDALICENSE.GOV,State,Non-Federal Agency,Department of Business and Professional Regulation,Tallahasssee,FL,robin.jordan@myfloridalicense.com
 MYFLORIDATREASUREHUNT.GOV,State,Non-Federal Agency,FL Dept of Financial Services,Tallahassee,FL,Clint.Morrow@myfloridacfo.com
 MYHAWAII.GOV,State,Non-Federal Agency,DAGS/ICSD,Honolulu,HI,(blank)
-MYIN.GOV,State,Non-Federal Agency,Intelenet Commission,Indianapolis,IN,mjohnson@iot.in.gov
-MYINDIANA.GOV,State,Non-Federal Agency,Intelenet Commission,Indianapolis,IN,mjohnson@iot.in.gov
+MYIN.GOV,State,Non-Federal Agency,Intelenet Commission,Indianapolis,IN,ewinblad@iot.in.gov
+MYINDIANA.GOV,State,Non-Federal Agency,Intelenet Commission,Indianapolis,IN,ewinblad@iot.in.gov
 MYKENTUCKY.GOV,State,Non-Federal Agency,Commonwealth of Kentucky Cabinet for Health and Family Services,Frankfort,KY,(blank)
 MYKY.GOV,State,Non-Federal Agency,Commonwealth of Kentucky Cabinet for Health and Family Services,Frankfort,KY,(blank)
 MYNCDMV.GOV,State,Non-Federal Agency,NC Department of Transportation,Raleigh,NC,(blank)
@@ -6508,6 +6540,7 @@ NCSBADVISORS.GOV,State,Non-Federal Agency,North Carolina Department of Commerce,
 NCSBE-APPS.GOV,State,Non-Federal Agency,North Carolina State Board of Elections,Raleigh,NC,torry.crass@ncsbe.gov
 NCSBE.GOV,State,Non-Federal Agency,State Board of Elections,Raleigh,NC,torry.crass@ncsbe.gov
 NCSBI.GOV,State,Non-Federal Agency,North Carolina Department of Justice,Raleigh,NC,(blank)
+NCSPARTA.GOV,State,Non-Federal Agency,North Carolina Emergency Management,Raleigh,NC,DITPSInformationSecurity@ncdps.gov
 NCSTATE.GOV,State,Non-Federal Agency,NC State University,Raleigh,NC,(blank)
 NCUC.GOV,State,Non-Federal Agency,North Carolina Utilities Commission,Raleigh,NC,helpdesk@ncuc.net
 NCWORKS.GOV,State,Non-Federal Agency,Division of Workforce Solutions of the Department of Commerce,Raleigh,NC,Michael.terrell@nccommerce.com
@@ -6594,7 +6627,7 @@ NV.GOV,State,Non-Federal Agency,"State of Nevada, Department of Information Tech
 NV529.GOV,State,Non-Federal Agency,Nevada State Treasurer's Office,Carson City,NV,security-abuse@nevadatreasurer.gov
 NVAGOMLA.GOV,State,Non-Federal Agency,NV Office of the Attorney General,Carson City,NV,(blank)
 NVCOGCT.GOV,State,Non-Federal Agency,Naugatuck Valley Council of Governments,Waterbury,CT,nvcog@nvcogct.org
-NVCOURTS.GOV,State,Non-Federal Agency,Supreme Court of Nevada,Carson City,NV,(blank)
+NVCOURTS.GOV,State,Non-Federal Agency,Supreme Court of Nevada,Carson City,NV,webservices@nvcourts.nv.gov
 NVDPS.GOV,State,Non-Federal Agency,Enterprise IT Services Division,Carson City,NV,iso@dps.state.nv.us
 NVDPSPUB.GOV,State,Non-Federal Agency,Nevada Department of Public Safety,Carson City,NV,dmchugh@admin.nv.gov
 NVEASE.GOV,State,Non-Federal Agency,Nevada Secretary of State,Carson City,NV,(blank)


### PR DESCRIPTION
* 3 new federal executive domains (`energycommunities.gov`, `pcast.gov`, `power2prevent.gov`), 34 new domains in total
* For the first time (?), the .gov zone is over 7000 domains.