### PR TITLE
Update from 12 Oct 2021

### DIFF
--- a/current-federal.csv
+++ b/current-federal.csv
@@ -912,6 +912,7 @@ USSM.GOV,Federal Agency - Executive,General Services Administration,"GSA, OGP, W
 VOTE.GOV,Federal Agency - Executive,General Services Administration,"GSA, TTS",Washington,DC,gsa-vulnerability-reports@gsa.gov
 WDOL.GOV,Federal Agency - Executive,General Services Administration,"GSA, IQ, CAT",Washington,DC,gsa-vulnerability-reports@gsa.gov
 ATA.GOV,Federal Agency - Executive,GOV Domain OPS,Gov Domain OPS,Arlington,VA,(blank)
+DOMAINOPS.GOV,Federal Agency - Executive,GOV Domain OPS,Gov Domain OPS,Arlington,VA,registrar@dotgov.gov
 ECFC.GOV,Federal Agency - Executive,GOV Domain OPS,Gov Domain OPS,Arlington,VA,(blank)
 ERPO.GOV,Federal Agency - Executive,GOV Domain OPS,Gov Domain OPS,Arlington,VA,(blank)
 FED.US,Federal Agency - Executive,GOV Domain OPS,GOV Domain OPS,Arlington,VA,dotgov@cisa.dhs.gov
@@ -1203,8 +1204,10 @@ AMERICANMEMORY.GOV,Federal Agency - Legislative,Library of Congress,Library of C
 AMERICASLIBRARY.GOV,Federal Agency - Legislative,Library of Congress,Library of Congress,Washington,DC,security@loc.gov
 ASIANPACIFICHERITAGE.GOV,Federal Agency - Legislative,Library of Congress,Library of Congress,Washington,DC,security@loc.gov
 BLACKHISTORYMONTH.GOV,Federal Agency - Legislative,Library of Congress,Library of Congress,Washington,DC,security@loc.gov
+CCB.GOV,Federal Agency - Legislative,Library of Congress,Library of Congress,Washington,DC,security@loc.gov
 CONGRESS.GOV,Federal Agency - Legislative,Library of Congress,Library of Congress,Washington,DC,security@loc.gov
 COPYRIGHT.GOV,Federal Agency - Legislative,Library of Congress,Library of Congress,Washington,DC,security@loc.gov
+COPYRIGHTCLAIMSBOARD.GOV,Federal Agency - Legislative,Library of Congress,Library of Congress,Washington,DC,security@loc.gov
 CRB.GOV,Federal Agency - Legislative,Library of Congress,Copyright Royalty Board,Washington,DC,security@loc.gov
 CRS.GOV,Federal Agency - Legislative,Library of Congress,Congressional Research Service,Washington,DC,security@loc.gov
 DIGITALPRESERVATION.GOV,Federal Agency - Legislative,Library of Congress,Library of Congress,Washington,DC,security@loc.gov

--- a/current-full.csv
+++ b/current-full.csv
@@ -48,7 +48,7 @@ ALTAVISTAVA.GOV,City,Non-Federal Agency,Town of Altavista,Altavista,VA,tcshelton
 ALTON-TX.GOV,City,Non-Federal Agency,City of Alton,Alton,TX,(blank)
 ALTOONAPA.GOV,City,Non-Federal Agency,City of Altoona,Altoona,PA,(blank)
 ALTUSOK.GOV,City,Non-Federal Agency,City of Altus,Altus,OK,(blank)
-ALVIN-TX.GOV,City,Non-Federal Agency,"City of Alvin, Texas",Alvin,TX,(blank)
+ALVIN-TX.GOV,City,Non-Federal Agency,"City of Alvin, Texas",Alvin,TX,info@cityofalvin.com
 AMARILLO.GOV,City,Non-Federal Agency,City of Amarillo ,Amarillo,TX,(blank)
 AMENIANY.GOV,City,Non-Federal Agency,Town of Amenia,Amenia,NY,(blank)
 AMERICANFORK.GOV,City,Non-Federal Agency,American Fork City,American Fork,UT,george@americanfork.gov
@@ -94,6 +94,7 @@ ARCHBALDBOROUGHPA.GOV,City,Non-Federal Agency,Archbald Borough,Archbald,PA,(blan
 ARCHDALE-NC.GOV,City,Non-Federal Agency,City of Archdale,ARCHDALE,NC,_it@archdale-nc.gov
 ARCHERLODGENC.GOV,City,Non-Federal Agency,Town of Archer Lodge,Archer Lodge,NC,(blank)
 ARCOLATEXAS.GOV,City,Non-Federal Agency,City of Arcola,Arcola,TX,contractor1@arcolatexas.org
+ARDMOREOK.GOV,City,Non-Federal Agency,City of Ardmore,Ardmore,OK,abuse@ardmorecity.org
 ARKADELPHIA.GOV,City,Non-Federal Agency,City of Arkadelphia,Arkadelphia,AR,(blank)
 ARKANSASCITYKS.GOV,City,Non-Federal Agency,City of Arkansas City,Arkansas City,KS,security@arkansascityks.gov
 ARLINGTON-TX.GOV,City,Non-Federal Agency,"City of Arlington, Texas",Arlington,TX,itregistrar@arlingtontx.gov
@@ -378,7 +379,7 @@ CALDWELLTX.GOV,City,Non-Federal Agency,City of Caldwell,Caldwell,TX,(blank)
 CALEDONIA-WI.GOV,City,Non-Federal Agency,Village of Caledonia,Racine,WI,(blank)
 CALEDONIAMN.GOV,City,Non-Federal Agency,City of Caledonia,Caledonia,MN,(blank)
 CALEDONIAOH.GOV,City,Non-Federal Agency,Village of Caledonia,Caledonia,OH,shane@tigmun.com
-CALHOUNFALLS.GOV,City,Non-Federal Agency,Town of Calhoun Falls,Calhoun Falls,SC,rd@ccm2.com
+CALHOUNFALLS.GOV,City,Non-Federal Agency,Town of Calhoun Falls,Calhoun Falls,SC,cfadvocate@wctel.net
 CALIFORNIACITY-CA.GOV,City,Non-Federal Agency,City of California City,California City,CA,(blank)
 CALUMETTWP-IN.GOV,City,Non-Federal Agency,Calumet Township Trustee Office,Gary,IN,(blank)
 CALVERTCITYKY.GOV,City,Non-Federal Agency,City of Calvert City,Calvert City,KY,support@smartpathtech.com
@@ -906,6 +907,7 @@ DURHAMNC.GOV,City,Non-Federal Agency,City of Durham,Durham,NC,(blank)
 DUSHOREPA.GOV,City,Non-Federal Agency,Dushore Borough,Dushore,PA,zachwest@west-systems.com
 DUTCHESSNY.GOV,City,Non-Federal Agency,Dutchess Co. Office of Computer Information Services,Poughkeepsie,NY,(blank)
 DUVALLWA.GOV,City,Non-Federal Agency,City of Duvall,Duvall,WA,(blank)
+DUXBURY-MA.GOV,City,Non-Federal Agency,Town of Duxbury,Duxbury,MA,escarpino@duxbury.k12.ma.us
 DWGPA.GOV,City,Non-Federal Agency,Borough of Delaware Water Gap,Delaware Water Gap,PA,boro@dwgpa.gov
 DYERSBURGTN.GOV,City,Non-Federal Agency,City of Dyersburg,Dyersburg,TN,(blank)
 EAGANMN.GOV,City,Non-Federal Agency,City of Eagan,Eagan,MN,jwilske@cityofeagan.com
@@ -926,7 +928,7 @@ EASTKINGSTONNH.GOV,City,Non-Federal Agency,Town of East Kingston NH,East Kingsto
 EASTLANDTEXAS.GOV,City,Non-Federal Agency,City of Eastland,Eastland,TX,(blank)
 EASTLONGMEADOWMA.GOV,City,Non-Federal Agency,Town of East Longmeadow,East Longmeadow,MA,it-staff@eastlongmeadowma.gov
 EASTMOUNTAINTX.GOV,City,Non-Federal Agency,City of East Mountain,East Mountain,TX,marc.covington@eastmountaintx.gov
-EASTON-PA.GOV,City,Non-Federal Agency,City of Easton,Easton,PA,fcaruso@easton-pa.gov
+EASTON-PA.GOV,City,Non-Federal Agency,City of Easton,Easton,PA,mfares@easton-pa.gov
 EASTONCT.GOV,City,Non-Federal Agency,"Town of Easton, Connecticut, USA",Easton,CT,(blank)
 EASTONMD.GOV,City,Non-Federal Agency,Town of Easton,Easton,MD,(blank)
 EASTORANGE-NJ.GOV,City,Non-Federal Agency,City Of East ORange,East ORange,NJ,carlos.valentin@eastorange-nj.gov
@@ -962,6 +964,7 @@ EHAMPTONNY.GOV,City,Non-Federal Agency,Town of East Hampton,East Hampton,NY,Tech
 ELBAAL.GOV,City,Non-Federal Agency,"City of Elba, Alabama",Elba,AL,jnagy@m4technologycorp.com
 ELCAJON.GOV,City,Non-Federal Agency,City of El Cajon,El Cajon,CA,webmaster@cityofelcajon.us
 ELCENIZOTX.GOV,City,Non-Federal Agency,City of El Cenizo,El Cenizo,TX,rjesus846@hotmail.com
+ELIZABETHCITYNC.GOV,City,Non-Federal Agency,City of Elizabeth City,Elizabeth City,NC,directors@cityofec.com
 ELIZABETHTOWNKY.GOV,City,Non-Federal Agency,City of Elizabethtown,Elizabethtown,KY,admin@elizabethtownky.gov
 ELKGROVEIL.GOV,City,Non-Federal Agency,Village of Elk Grove,Elk Grove Village,IL,is@elkgrove.org
 ELKHARTLAKEWI.GOV,City,Non-Federal Agency,Village of Elkhart Lake,Elkhart Lake,WI,(blank)
@@ -1151,7 +1154,7 @@ GARDINERMAINE.GOV,City,Non-Federal Agency,City of Gardiner,gardiner,ME,(blank)
 GARDNER-MA.GOV,City,Non-Federal Agency,CITY OF GARDNER,GARDNER,MA,rokeefe@gardner-ma.gov
 GARDNERKANSAS.GOV,City,Non-Federal Agency,City of Gardner,Gardner,KS,itservice@gardnerkansas.gov
 GARLANDTX.GOV,City,Non-Federal Agency,City of Garland,Garland,TX,(blank)
-GARNERNC.GOV,City,Non-Federal Agency,"Town of Garner, NC",Garner,NC,(blank)
+GARNERNC.GOV,City,Non-Federal Agency,"Town of Garner, NC",Garner,NC,erucker@garnernc.gov
 GARRETTPARKMD.GOV,City,Non-Federal Agency,Town of Garrett Park,Garrett Park,MD,it_security@garrettparkmd.gov
 GARY.GOV,City,Non-Federal Agency,City of Gary,Gary,IN,lkeith@ci.gary.in.us
 GATLINBURGTN.GOV,City,Non-Federal Agency,City of Gatlinburg,Gatlinburg,TN,(blank)
@@ -1262,6 +1265,7 @@ HADLEYMA.GOV,City,Non-Federal Agency,Town of Hadley,Hadley,MA,(blank)
 HAHIRAGA.GOV,City,Non-Federal Agency,"Hahira, Georgia",Hahira,GA,(blank)
 HALIFAXMA.GOV,City,Non-Federal Agency,"Town of Halifax, MA",Halifax,MA,OITC@halifax-ma.org
 HALLANDALEBEACHFL.GOV,City,Non-Federal Agency,"Hallandale Beach, City of",hallandale beach,FL,rcastillo@northmiamifl.gov
+HALSEYOR.GOV,City,Non-Federal Agency,City of Halsey,Halsey,OR,it@cityofhalsey.com
 HALTOMCITYTX.GOV,City,Non-Federal Agency,city of Haltom City,Haltom City,TX,its@haltomcitytx.com
 HAMILTON-NY.GOV,City,Non-Federal Agency,VILLAGE OF HAMILTON,HAMILTON,NY,mollyr@garamgroup.com
 HAMILTON-OH.GOV,City,Non-Federal Agency,"City of Hamilton, Ohio",Hamilton,OH,(blank)
@@ -1338,6 +1342,7 @@ HERMONMAINE.GOV,City,Non-Federal Agency,Town of Hermon,Hermon,ME,(blank)
 HERMOSABEACH.GOV,City,Non-Federal Agency,City of Hermosa Beach,Hermosa Beach,CA,customer.care@prosum.com
 HERNDON-VA.GOV,City,Non-Federal Agency,Town of Herndon,Herndon,VA,jim.burr@herndon-va.gov
 HESPERIACA.GOV,City,Non-Federal Agency,City Of Hesperia,Hesperia,CA,(blank)
+HEWLETTBAYPARKNY.GOV,City,Non-Federal Agency,village of hewlett bay park,Hewlett,NY,villages3@optimum.net
 HEYWORTH-IL.GOV,City,Non-Federal Agency,Village of Heyworth,Heyworth,IL,(blank)
 HFSCTX.GOV,City,Non-Federal Agency,Houston Forensic Science Center,Houston,TX,IT@houstonforensicscience.org
 HGCITYCA.GOV,City,Non-Federal Agency,City of Hawaiian Gardens,Hawaiian Gardens,CA,(blank)
@@ -1545,7 +1550,7 @@ LAGUNAHILLSCA.GOV,City,Non-Federal Agency,City of Laguna Hills,Laguna Hills,CA,(
 LAHABRA.GOV,City,Non-Federal Agency,CIYT OF LA HABRA,La Habra,CA,lahabrait@lahabraca.gov
 LAHABRACA.GOV,City,Non-Federal Agency,CITY OF LA HABRA,LA HABRA,CA,(blank)
 LAKECITYSC.GOV,City,Non-Federal Agency,City of Lake City,Lake City,SC,(blank)
-LAKEFORESTCA.GOV,City,Non-Federal Agency,City of Lake Forest,Lake Forest,CA,(blank)
+LAKEFORESTCA.GOV,City,Non-Federal Agency,City of Lake Forest,Lake Forest,CA,colfhelpdesk@abtechtechnologies.com
 LAKEGROVENY.GOV,City,Non-Federal Agency,Village of Lake Grove,Lake Grove,NY,(blank)
 LAKEHURST-NJ.GOV,City,Non-Federal Agency,City Connections,Hazlet,NJ,(blank)
 LAKEJACKSON-TX.GOV,City,Non-Federal Agency,City of Lake Jackson,Lake Jackson,TX,it@LAKEJACKSONTX.GOV
@@ -1577,7 +1582,7 @@ LANESBORO-MN.GOV,City,Non-Federal Agency,City of Lanesboro,Lanesboro,MN,(blank)
 LANESBOROUGH-MA.GOV,City,Non-Federal Agency,TOWN OF LANESBOROUGH,LANESBOROUGH,MA,(blank)
 LANSINGMI.GOV,City,Non-Federal Agency,City of Lansing - Information Technology,Lansing,MI,itsecurity@lansingmi.gov
 LANTABUS-PA.GOV,City,Non-Federal Agency,Lehigh and Northampton Transportation Authority,Allentown,PA,(blank)
-LAPINEOREGON.GOV,City,Non-Federal Agency,City of La Pine,La Pine,OR,mbethel@lapineoregon.gov
+LAPINEOREGON.GOV,City,Non-Federal Agency,City of La Pine,La Pine,OR,gwullschlager@lapine.gov
 LAPORTETX.GOV,City,Non-Federal Agency,City of La Porte,La Porte,TX,IT@laportetx.gov
 LAQUINTACA.GOV,City,Non-Federal Agency,City of La Quinta,La Quinta,CA,(blank)
 LARCHMONTNY.GOV,City,Non-Federal Agency,Village of Larchmont,Larchmont,NY,security@villageoflarchmont.org
@@ -1678,7 +1683,7 @@ LONGVIEWTX.GOV,City,Non-Federal Agency,"City of Longview, TX",Longview,TX,(blank
 LORENATX.GOV,City,Non-Federal Agency,City of Lorena Texas,Lorena,TX,(blank)
 LOSALTOSCA.GOV,City,Non-Federal Agency,City of Los Altos,Los Altos,CA,(blank)
 LOSGATOSCA.GOV,City,Non-Federal Agency,Town of Los Gatos,Los Gatos,CA,skim@losgatosca.gov
-LOSLUNASNM.GOV,City,Non-Federal Agency,Village of Los Lunas,Los Lunas,NM,(blank)
+LOSLUNASNM.GOV,City,Non-Federal Agency,Village of Los Lunas,Los Lunas,NM,support@loslunasnm.gov
 LOSRANCHOSNM.GOV,City,Non-Federal Agency,Village of Los Ranchos de Albuquerque,Los Ranchos de Albuquerque,NM,(blank)
 LOTT-TX.GOV,City,Non-Federal Agency,City of Lott,Lott,TX,(blank)
 LOUISBURGKANSAS.GOV,City,Non-Federal Agency,City of Louisburg,Louisburg,KS,(blank)
@@ -1877,7 +1882,7 @@ MINNETONKA-MN.GOV,City,Non-Federal Agency,City of Minnetonka,Minnetonka,MN,(blan
 MINNETONKAMN.GOV,City,Non-Federal Agency,City of Minnetonka,Minnetonka,MN,(blank)
 MINTHILL.GOV,City,Non-Federal Agency,Town of Mint Hill,Mint Hill,NC,vapostu@compunetworld.net
 MIRAMAR-FL.GOV,City,Non-Federal Agency,City of Miramar,Miramar,FL,(blank)
-MIRAMARFL.GOV,City,Non-Federal Agency,The City of Miramar,Miramar,FL,mebrito@miramarfl.gov
+MIRAMARFL.GOV,City,Non-Federal Agency,The City of Miramar,Miramar,FL,babrewster@miramarfl.gov
 MISSIONHILLSKS.GOV,City,Non-Federal Agency,"City of Mission Hills, KS",Mission Hills,KS,(blank)
 MISSOURICITYTEXAS.GOV,City,Non-Federal Agency,"City of Missouri City, Texas",Missouri City,TX,(blank)
 MISSOURICITYTX.GOV,City,Non-Federal Agency,City of Missouri City,Missouri City,TX,mwolf@missouricitytx.gov
@@ -1897,6 +1902,7 @@ MONTCLAIRCA.GOV,City,Non-Federal Agency,City of Montclair,Montclair,CA,abuse@cit
 MONTEREYMA.GOV,City,Non-Federal Agency,Town of Monterey,Monterey,MA,(blank)
 MONTGOMERYAL.GOV,City,Non-Federal Agency,City of Montgomery,Montgomery,AL,(blank)
 MONTGOMERYMA.GOV,City,Non-Federal Agency,Town of Montgomery,Montgomery,MA,(blank)
+MONTGOMERYNJ.GOV,City,Non-Federal Agency,Township of Montgomery,Belle Mead,NJ,jferrara@police.montgomery.nj.us
 MONTGOMERYOHIO.GOV,City,Non-Federal Agency,City of Montgomery,Montgomery,OH,mvanderhorst@montgomeryohio.org
 MONTGOMERYTEXAS.GOV,City,Non-Federal Agency,City of Montgomery,Montgomery,TX,jguptill@ocscorp.com
 MONTGOMERYWV.GOV,City,Non-Federal Agency,City of Montgomery,Montgomery,WV,gingram@montgomerywv.gov
@@ -1913,7 +1919,7 @@ MORGANTOWNKY.GOV,City,Non-Federal Agency,City of Morgantown,Morgantown,KY,womack
 MORGANTOWNWV.GOV,City,Non-Federal Agency,City of Morgantown,Morgantown,WV,tpovroznik@morgantownwv.gov
 MORIARTYNM.GOV,City,Non-Federal Agency,The City of Moriarty,Moriarty,NM,(blank)
 MORNINGSIDEMD.GOV,City,Non-Federal Agency,Town of Morningside,Morningside,MD,(blank)
-MORROBAYCA.GOV,City,Non-Federal Agency,City of Morro Bay,Morro Bay,CA,(blank)
+MORROBAYCA.GOV,City,Non-Federal Agency,City of Morro Bay,Morro Bay,CA,jgemma@gemmasys.com
 MORTON-IL.GOV,City,Non-Federal Agency,"City of Morton, IL",Morton,IL,cloudermilk@morton-il.gov
 MOSELWI.GOV,City,Non-Federal Agency,Town of Mosel,Sehboygan,WI,support@pros4technology.com
 MOULTONBOROUGHNH.GOV,City,Non-Federal Agency,Town of Moultonborough,Moultonborough,NH,(blank)
@@ -2414,6 +2420,7 @@ ROANOKEVA.GOV,City,Non-Federal Agency,City of Roanoke,Roanoke,VA,securitydotgov@
 ROBINSONPA.GOV,City,Non-Federal Agency,Robinson Township,McDonald,PA,(blank)
 ROCHELLEPARKNJ.GOV,City,Non-Federal Agency,Township of Rochelle Park,Rochelle Park,NJ,itdept@rochelleparknj.gov
 ROCHESTERMN.GOV,City,Non-Federal Agency,The City of Rochester,Rochester,MN,(blank)
+ROCHESTERWI.GOV,City,Non-Federal Agency,Village of Rochester,Rochester,WI,admin@rochesterwi.us
 ROCKFORD-IL.GOV,City,Non-Federal Agency,CITY OF ROCKFORD,Rockford,IL,(blank)
 ROCKFORDIL.GOV,City,Non-Federal Agency,City of Rockford,Rockford,IL,(blank)
 ROCKFORDTOWNSHIPIL.GOV,City,Non-Federal Agency,Rockford Township,Rockford,IL,jasperstangel@rockfordtownshipil.gov
@@ -2816,10 +2823,12 @@ TOWNOFCARYNC.GOV,City,Non-Federal Agency,Town of Cary,Cary,NC,(blank)
 TOWNOFCATSKILLNY.GOV,City,Non-Federal Agency,"Town of Catskill, NY",Catskill,NY,(blank)
 TOWNOFCHAPELHILLTN.GOV,City,Non-Federal Agency,Town of Chapel Hill,Chapel Hill,TN,(blank)
 TOWNOFCLEVELANDNC.GOV,City,Non-Federal Agency,"Town of Cleveland, North Carolina",Cleveland,NC,(blank)
+TOWNOFCRANMOOR.GOV,City,Non-Federal Agency,TOWN OF CRANMOOR,WISCONSIN RAPIDS,WI,cranmoorclerk@gmail.com
 TOWNOFCROWNPOINTNY.GOV,City,Non-Federal Agency,Town of Crown Point,Crown Point,NY,james.bullock@essexcountyny.gov
 TOWNOFDEERPARKNY.GOV,City,Non-Federal Agency,Town of Deerpark,Huguenot,NY,Info@townofdeerpark.org
 TOWNOFDUNNWI.GOV,City,Non-Federal Agency,Town of Dunn,McFarland,WI,(blank)
 TOWNOFESSEXNY.GOV,City,Non-Federal Agency,Town of Essex,Essex,NY,lturbini@co.essex.ny.us
+TOWNOFGERMANTOWNWI.GOV,City,Non-Federal Agency,TOWN OF GERMANTOWN,NEW LISBON,WI,techsec@townofgermantown.com
 TOWNOFGOLDENMEADOW-LA.GOV,City,Non-Federal Agency,Town of Golden Meadow,Golden Meadow,LA,jamie@townofgoldenmeadow-la.gov
 TOWNOFGRANVILLEWV.GOV,City,Non-Federal Agency,Town of Granville,Granville,WV,(blank)
 TOWNOFHALFMOON-NY.GOV,City,Non-Federal Agency,Town of Halfmoon,Halfmoon,NY,admin@townofhalfmoon.org
@@ -3170,17 +3179,18 @@ WINSLOW-ME.GOV,City,Non-Federal Agency,Town of Winslow,Winslow,ME,elacroix@winsl
 WINSLOWAZ.GOV,City,Non-Federal Agency,City Of Winslow,Winslow,AZ,(blank)
 WINTERGARDEN-FL.GOV,City,Non-Federal Agency,City of Winter Garden,Winter Garden,FL,(blank)
 WINTERPORTMAINE.GOV,City,Non-Federal Agency,"Winterport, Town of, Waldo Co. ME",Winterport,ME,(blank)
+WINTERSET.GOV,City,Non-Federal Agency,City of Winterset,Winterset,IA,dbarden@cwmu.net
 WINTERSPRINGSFL.GOV,City,Non-Federal Agency,City of Winter Springs,Winter Springs,FL,cows-is@winterspringsfl.org
 WOBURNMA.GOV,City,Non-Federal Agency,City of Woburn,Woburn,MA,cio@cityofwoburn.com
 WOODBURN-OR.GOV,City,Non-Federal Agency,City of Woodburn,Woodburn,OR,web_master@ci.woodburn.or.us
 WOODBURYMN.GOV,City,Non-Federal Agency,City of Woodbury,Woodbury,MN,mis2@woodburymn.gov
 WOODCREEKTX.GOV,City,Non-Federal Agency,City of Woodcreek,Woodcreek,TX,alerts@heartoftexasit.com
 WOODFIN-NC.GOV,City,Non-Federal Agency,The Town Of Woodfin,Woodfin,NC,(blank)
-WOODHEIGHTS-MO.GOV,City,Non-Federal Agency,City of Wood Heights,Wood Heights,MO,(blank)
+WOODHEIGHTS-MO.GOV,City,Non-Federal Agency,City of Wood Heights,Wood Heights,MO,marlermerry@gmail.com
 WOODLANDHILLS-UT.GOV,City,Non-Federal Agency,City of Woodland Hills,Woodland Hills,UT,chris@woodlandhills-ut.gov
 WOODRIDGEIL.GOV,City,Non-Federal Agency,VILLAGE OF WOODRIDGE,WOODRIDGE,IL,sbanda@vil.woodridge.il.us
 WOODSTOCKCT.GOV,City,Non-Federal Agency,Town of Woodstock,Woodstock,CT,(blank)
-WOODSTOCKGA.GOV,City,Non-Federal Agency,City of Woodstock,Woodstock,GA,(blank)
+WOODSTOCKGA.GOV,City,Non-Federal Agency,City of Woodstock,Woodstock,GA,itdept@woodstockga.gov
 WOODSTOCKIL.GOV,City,Non-Federal Agency,City of Woodstock,Woodstock,IL,support@woodstockil.gov
 WOODVILLAGEOR.GOV,City,Non-Federal Agency,City of Wood Village,Wood Village,OR,(blank)
 WOODVILLE-TX.GOV,City,Non-Federal Agency,"City of Woodville, Texas",Woodville,TX,(blank)
@@ -3286,6 +3296,7 @@ BLANDCOUNTYVA.GOV,County,Non-Federal Agency,"Bland County, Virginia",Bland,VA,(b
 BLOUNTCOUNTYAL.GOV,County,Non-Federal Agency,Blount County Commission,Oneonta,AL,info@blountcountyal.gov
 BLUEEARTHCOUNTYMN.GOV,County,Non-Federal Agency,Blue Earth County,Mankato,MN,(blank)
 BOERANDOLPHCOUNTYGA.GOV,County,Non-Federal Agency,Board of Elections & Registration,Cuthbert,GA,rc.boeandvr@gmail.com
+BONDCOUNTYIL.GOV,County,Non-Federal Agency,Bond County ,Greenville,IL,swight@bondcountyil.com
 BONNERCOID.GOV,County,Non-Federal Agency,Bonner County,Sandpoint,ID,(blank)
 BONNERCOUNTYID.GOV,County,Non-Federal Agency,Bonner County,Sandpoint,ID,technology@bonnercountyid.gov
 BONNEVILLECOUNTYID.GOV,County,Non-Federal Agency,Bonneville County Emergency Communications Center,Idaho Falls,ID,(blank)
@@ -3687,6 +3698,7 @@ JACKSONCOUNTY-IL.GOV,County,Non-Federal Agency,"Jackson County, Illinois",Murphy
 JACKSONCOUNTYAL.GOV,County,Non-Federal Agency,Jackson County Commission,Scottsboro,AL,(blank)
 JACKSONCOUNTYCO.GOV,County,Non-Federal Agency,Jackson County,Walden,CO,(blank)
 JACKSONCOUNTYFL.GOV,County,Non-Federal Agency,Jackson County Board of County Commissioners,Marianna,FL,jstackowicz@jacksoncountyfl.com
+JACKSONTWPCLERMONTOH.GOV,County,Non-Federal Agency,"Jackson Township, Clermont County Ohio",WILLIAMSBURG,OH,jacksontwpdomain@propelu4ward.com
 JAMESCITYCOUNTYVA.GOV,County,Non-Federal Agency,James City County,Williamsburg,VA,(blank)
 JASPERCOUNTYIN.GOV,County,Non-Federal Agency,Jasper County Government,Rensselaer,IN,(blank)
 JASPERCOUNTYMO.GOV,County,Non-Federal Agency,Jasper County Missouri,Carthage,MO,support@midwest-it.com
@@ -3839,6 +3851,7 @@ MCCRACKENCOUNTYKY.GOV,County,Non-Federal Agency,McCracken County Fiscal Court,Pa
 MCCURTAINEMS.GOV,County,Non-Federal Agency,McCurtain County EMS,Idabel,OK,(blank)
 MCDONALDCOUNTYMO.GOV,County,Non-Federal Agency,"County of McDonald, Missouri",Pineville,MO,gregg.sweeten@mcdonaldcountymo.gov
 MCDOWELLCOUNTYNCBOE.GOV,County,Non-Federal Agency,McDowell County Board of Elections,Marion,NC,rayburn.davis@mcdowellgov.com
+MCDOWELLCOUNTYWV.GOV,County,Non-Federal Agency,McDowell County Commission,Welch,WV,wimmerjen@hotmail.com
 MCHENRYCOUNTYIL.GOV,County,Non-Federal Agency,McHenry County Government Center,Woodstock,IL,(blank)
 MCHENRYCOUNTYILLINOIS.GOV,County,Non-Federal Agency,McHenry County Government Center,Woodstock,IL,(blank)
 MCINTOSHCOUNTY-GA.GOV,County,Non-Federal Agency,McIntosh County Booard of Commssioners,Darien,GA,(blank)
@@ -4130,6 +4143,7 @@ STLOUISCOUNTYMN.GOV,County,Non-Federal Agency,St. Louis County,Duluth,MN,(blank)
 STLOUISCOUNTYMO.GOV,County,Non-Federal Agency,St. Louis County Government,Clayton,MO,majero@stlouisco.com
 STLOUISCOUNTYMOVOTES.GOV,County,Non-Federal Agency,St. Louis County Board of Elections,St. Ann,MO,edboec@stlouisco.com
 STMARYPARISHLA.GOV,County,Non-Federal Agency,ST. MARY PARISH GOVERNMENT,FRANKLIN,LA,it@stmaryparishla.gov
+STMARYSCOUNTYMD.GOV,County,Non-Federal Agency,Saint Mary's County Government,Leonardtown,MD,mark.khatiblou@stmarysmd.com
 STOKESCOUNTYNC.GOV,County,Non-Federal Agency,Stokes County,Danbury,NC,informationsystems@co.stokes.nc.us
 STONECOUNTYMO.GOV,County,Non-Federal Agency,STONE COUNTY,GALENA,MO,STONE.CYBERDEFENSE@GMAIL.COM
 STONECOUNTYMS.GOV,County,Non-Federal Agency,Stone County Board of Supervisors,Wiggins,MS,(blank)
@@ -4239,8 +4253,10 @@ WASHCOWISCO.GOV,County,Non-Federal Agency,washington county,west bend,WI,joel.wo
 WASHINGTONCOUNTYAR.GOV,County,Non-Federal Agency,Washington County,FAYETTEVILLE,AR,ltolan@co.washington.ar.us
 WASHINGTONCOUNTYGA.GOV,County,Non-Federal Agency,Washington County Board of Commissioners ,Sandersville,GA,(blank)
 WASHINGTONCOUNTYKS.GOV,County,Non-Federal Agency,Washington County,Washington,KS,(blank)
+WASHINGTONCOUNTYNE.GOV,County,Non-Federal Agency,Washington County Courthouse,Blair,NE,james.urwiller@turnkeynerds.com
 WASHINGTONCOUNTYNY.GOV,County,Non-Federal Agency,Washington County,Fort Edward,NY,kpratt@washingtoncountyny.gov
 WASHINGTONCOUNTYOR.GOV,County,Non-Federal Agency,Washington County,Hillsboro,OR,george_fenton@co.washington.or.us
+WASHINGTONCOUNTYSHERIFFNE.GOV,County,Non-Federal Agency,Washington County Sheriff,Blair,NE,james.urwiller@turnkeynerds.com
 WASHINGTONCOUNTYWI.GOV,County,Non-Federal Agency,Washington County,West Bend,WI,joel.woppert@washcowisco.gov
 WASHOECOUNTY.GOV,County,Non-Federal Agency,Washoe County,Reno,NV,itsecurity@washoecounty.us
 WASHOZWI.GOV,County,Non-Federal Agency,Washington County,West Bend,WI,joel.woppert@washcowisco.gov
@@ -5222,6 +5238,7 @@ USSM.GOV,Federal Agency - Executive,General Services Administration,"GSA, OGP, W
 VOTE.GOV,Federal Agency - Executive,General Services Administration,"GSA, TTS",Washington,DC,gsa-vulnerability-reports@gsa.gov
 WDOL.GOV,Federal Agency - Executive,General Services Administration,"GSA, IQ, CAT",Washington,DC,gsa-vulnerability-reports@gsa.gov
 ATA.GOV,Federal Agency - Executive,GOV Domain OPS,Gov Domain OPS,Arlington,VA,(blank)
+DOMAINOPS.GOV,Federal Agency - Executive,GOV Domain OPS,Gov Domain OPS,Arlington,VA,registrar@dotgov.gov
 ECFC.GOV,Federal Agency - Executive,GOV Domain OPS,Gov Domain OPS,Arlington,VA,(blank)
 ERPO.GOV,Federal Agency - Executive,GOV Domain OPS,Gov Domain OPS,Arlington,VA,(blank)
 FED.US,Federal Agency - Executive,GOV Domain OPS,GOV Domain OPS,Arlington,VA,dotgov@cisa.dhs.gov
@@ -5513,8 +5530,10 @@ AMERICANMEMORY.GOV,Federal Agency - Legislative,Library of Congress,Library of C
 AMERICASLIBRARY.GOV,Federal Agency - Legislative,Library of Congress,Library of Congress,Washington,DC,security@loc.gov
 ASIANPACIFICHERITAGE.GOV,Federal Agency - Legislative,Library of Congress,Library of Congress,Washington,DC,security@loc.gov
 BLACKHISTORYMONTH.GOV,Federal Agency - Legislative,Library of Congress,Library of Congress,Washington,DC,security@loc.gov
+CCB.GOV,Federal Agency - Legislative,Library of Congress,Library of Congress,Washington,DC,security@loc.gov
 CONGRESS.GOV,Federal Agency - Legislative,Library of Congress,Library of Congress,Washington,DC,security@loc.gov
 COPYRIGHT.GOV,Federal Agency - Legislative,Library of Congress,Library of Congress,Washington,DC,security@loc.gov
+COPYRIGHTCLAIMSBOARD.GOV,Federal Agency - Legislative,Library of Congress,Library of Congress,Washington,DC,security@loc.gov
 CRB.GOV,Federal Agency - Legislative,Library of Congress,Copyright Royalty Board,Washington,DC,security@loc.gov
 CRS.GOV,Federal Agency - Legislative,Library of Congress,Congressional Research Service,Washington,DC,security@loc.gov
 DIGITALPRESERVATION.GOV,Federal Agency - Legislative,Library of Congress,Library of Congress,Washington,DC,security@loc.gov
@@ -5597,6 +5616,7 @@ CALIFORNIAINTEGRATEDTRAVEL.GOV,Independent Intrastate Agency,Non-Federal Agency,
 CALIFORNIAPASS.GOV,Independent Intrastate Agency,Non-Federal Agency,Capitol Corridor Joint Powers Authority,Oakland,CA,info@capitolcorridor.org
 CALITP.GOV,Independent Intrastate Agency,Non-Federal Agency,Capitol Corridor,OAKLAND,CA,info@capitolcorridor.org
 CAMBRIDGERETIREMENTMA.GOV,Independent Intrastate Agency,Non-Federal Agency,City of Cambridge Contributory Retirement System,Cambridge,MA,cburns@cambridgeretirementma.gov
+CENTRECOUNTYVOTES.GOV,Independent Intrastate Agency,Non-Federal Agency,Centre County Government ,Bellefonte,PA,infosec@centrecountypa.gov
 CHAMPAIGNCOUNTYCLERKIL.GOV,Independent Intrastate Agency,Non-Federal Agency,Champaign County Clerk,Urbana,IL,security@champaigncountyclerkIL.gov
 CHSVOTES.GOV,Independent Intrastate Agency,Non-Federal Agency,Charleston County Board of Elections & Voter Registration,North Charleston,SC,bevr@charlestoncounty.org
 COLLIERVOTES.GOV,Independent Intrastate Agency,Non-Federal Agency,Collier County Supervisor of Elections,Naples,FL,itsoe@colliercountyfl.gov
@@ -5617,6 +5637,7 @@ IL12THCOURT.GOV,Independent Intrastate Agency,Non-Federal Agency,Illinois 12th C
 JEMS-IL.GOV,Independent Intrastate Agency,Non-Federal Agency,Northwest Central Joint Emergency Management System,Arlington Heights,IL,(blank)
 LAWRENCECOUNTYMO911.GOV,Independent Intrastate Agency,Non-Federal Agency,Lawrence County Emergency Services Board 9-1-1,Mt. Vernon,MO,911emamonettlawco@cityofmonett.com
 LCEMSAMI.GOV,Independent Intrastate Agency,Non-Federal Agency,Lake Charlevoix Emergency Service Authority,Charlevoix,MI,domainadmin@charlevoixmi.gov
+LCFWASA.GOV,Independent Intrastate Agency,Non-Federal Agency,Lower Cape Fear Water and Sewer Authority,Leland,NC,security@lcfwasa.org
 LPCD-LAFLA.GOV,Independent Intrastate Agency,Non-Federal Agency,LAFAYETTE PARISH COMMUNICATION DISTRICT,LAFAYETTE,LA,jthompson@lafayettela.gov
 LPCDOPS-LAFLA.GOV,Independent Intrastate Agency,Non-Federal Agency,LAFAYETTE PARISH COMMUNICATION DISTRICT,LAFAYETTE,LA,jthompson@lafayettela.gov
 MANATEEPAO.GOV,Independent Intrastate Agency,Non-Federal Agency,Manatee County Property Appraiser,Bradenton,FL,paoit@manateepao.com
@@ -6126,7 +6147,7 @@ COURTSWV.GOV,State,Non-Federal Agency,West Virginia Supreme Court of Appeals,Cha
 COVERME.GOV,State,Non-Federal Agency,State of Maine Office of Information Technology,Augusta,ME,Chad.Perkins@maine.gov
 COWORKFORCE.GOV,State,Non-Federal Agency,Colorado Dept Labor and Employement,Denver,CO,(blank)
 CSIMT.GOV,State,Non-Federal Agency,"Montana Office of the Commissioner of Securities and Insurance, Montana State Auditor",Helena,MT,(blank)
-CT.GOV,State,Non-Federal Agency,State of CT/Department of Administrative Services,Hartford,CT,
+CT.GOV,State,Non-Federal Agency,State of CT/Department of Administrative Services,Hartford,CT, 
 CTALERT.GOV,State,Non-Federal Agency,State of Connecticut Department of Emergency Services and Public Protection,Middletown,CT,(blank)
 CTBROWNFIELDS.GOV,State,Non-Federal Agency,State of Connecticut Dept. of Economic & Community Development,Hartford,CT,(blank)
 CTGROWN.GOV,State,Non-Federal Agency,CT Department of Agriculture,Hartford,CT,(blank)
@@ -6203,7 +6224,6 @@ FLORIDACONSUMERHELP.GOV,State,Non-Federal Agency,Florida Department of Agricultu
 FLORIDACRASHPORTAL.GOV,State,Non-Federal Agency,Florida Department of Highway Safety and Motor Vehicles,Tallahassee,FL,ScottMorgan@flhsmv.gov
 FLORIDADEP.GOV,State,Non-Federal Agency,Department of Environmental Protection,Tallahassee,FL,(blank)
 FLORIDADOS.GOV,State,Non-Federal Agency,Florida Department of State,Tallahassee,FL,Security@dos.myflorida.com
-FLORIDAELECTION2020.GOV,State,Non-Federal Agency,Florida Department of State,Tallahassee,FL,security@dos.myflorida.com
 FLORIDAELECTIONWATCH.GOV,State,Non-Federal Agency,Florida Department of State,Tallahassee,FL,Security@dos.myflorida.com
 FLORIDAFX.GOV,State,Non-Federal Agency,Agency for Health Care Administration,Tallahassee,FL,william.armstrong@ahca.myflorida.com
 FLORIDAGIO.GOV,State,Non-Federal Agency,FL Department of Environmental Protection,Tallahassee,FL,(blank)
@@ -6310,7 +6330,7 @@ ILLINOISCOURTS.GOV,State,Non-Federal Agency,Administrative Office of the Illinoi
 ILLINOISRETIREMENT.GOV,State,Non-Federal Agency,Illinois State Treasurer's Office,Springfield,IL,JDaniels@illinoistreasurer.gov
 ILLINOISTREASURER.GOV,State,Non-Federal Agency,Illinois State Treasurer's Office,Springfield,IL,(blank)
 ILSOS.GOV,State,Non-Federal Agency,Illinois Secretary of State,Springfield,IL,SecurityAdministrator@ilsos.net
-IN.GOV,State,Non-Federal Agency,State of Indiana,Indianapolis,IN,ewinblad@iot.in.gov
+IN.GOV,State,Non-Federal Agency,State of Indiana,Indianapolis,IN,IOTOperationalSecurity@iot.in.gov
 INCOURTS.GOV,State,Non-Federal Agency,Indiana Office of Technology,Indianapolis,IN,(blank)
 INDIANA.GOV,State,Non-Federal Agency,Indiana Interactive,Indianapolis,IN,ewinblad@iot.in.gov
 INDIANAUNCLAIMED.GOV,State,Non-Federal Agency,Indiana Office of the Attorney General,Indianapolis,IN,(blank)
@@ -6377,6 +6397,7 @@ KS.GOV,State,Non-Federal Agency,"State of Kansas, DISC",Topeka,KS,mark.abraham@k
 KSABCONLINE.GOV,State,Non-Federal Agency,Kansas Department of Revenue,Topeka,KS,vince.finney@ks.gov
 KSCAREERNAV.GOV,State,Non-Federal Agency,Kansas Department of Commerce,Topeka,KS,jude.anyere@ks.gov
 KSCJIS.GOV,State,Non-Federal Agency,Kansas Highway Patrol,Topeka,KS,(blank)
+KSDOT.GOV,State,Non-Federal Agency,Kansas Department of Transportation,Topeka,KS,kiso@ks.gov
 KSELIEN.GOV,State,Non-Federal Agency,Kansas Department of Revenue,Topeka,KS,vince.finney@ks.gov
 KSREADY.GOV,State,Non-Federal Agency,Kansas Division of Emergency Management,Topeka,KS,(blank)
 KSREVENUE.GOV,State,Non-Federal Agency,Kansas Department of Revenue,Topeka,KS,vince.finney@ks.gov
@@ -6390,6 +6411,7 @@ LAFASTSTART.GOV,State,Non-Federal Agency,Louisiana Economic Development,Baton Ro
 LAJUDICIAL.GOV,State,Non-Federal Agency,State of Louisiana Judicial Branch,New Orleans,LA,iteam@lasc.org
 LCSAMI.GOV,State,Non-Federal Agency,Local Community Stabilization Authority,Lansing,MI,(blank)
 LEGMT.GOV,State,Non-Federal Agency,"Department of Administration, State of Montana",Helena,MT,(blank)
+LEYESLABORALESDECOLORADO.GOV,State,Non-Federal Agency,Division of Labor Standards and Statistics,Suite 600,CO,(blank)
 LGADMI.GOV,State,Non-Federal Agency,Department of Technology Management Budget,Lansing,MI,abuse@michigan.gov
 LICENSEDINIOWA.GOV,State,Non-Federal Agency,State of Iowa - OCIO,Des Moines,IA,soc@iowa.gov
 LISTOVIRGINIA.GOV,State,Non-Federal Agency,Virginia Department of Emergency Management,Richmond,VA,(blank)
@@ -6462,6 +6484,7 @@ MSLMI.GOV,State,Non-Federal Agency,Department of Technology Management Budget,La
 MSPADMI.GOV,State,Non-Federal Agency,Department of Technology Management Budget,Lansing,MI,abuse@michigan.gov
 MT.GOV,State,Non-Federal Agency,State of Montana,Helena,MT,doasitsdnosc@mt.gov
 MTCOUNTYRESULTS.GOV,State,Non-Federal Agency,Montana Secretary of State,Helena,MT,(blank)
+MTDNRC.GOV,State,Non-Federal Agency,Department of Natural Resources and Conservation,Helena,MT,DNRSecurity@mt.gov
 MTELECTIONRESULTS.GOV,State,Non-Federal Agency,mtelectionresults.gov,Helena,MT,(blank)
 MTLEG.GOV,State,Non-Federal Agency,"Department of Administration, State of Montana",Helena,MT,ACurtis@mt.gov
 MTLEGNEWS.GOV,State,Non-Federal Agency,Montana Legislative Branch,Helena,MT,legitsecurity@mt.gov


### PR DESCRIPTION
24 new domains, including 2 new federal domains (`ccb.gov` and `copyrightclaimsboard.gov`), both from the Library of Congress. A .gov program domain, `domainops.gov`, was also created.