### PR TITLE
Add 1 CNCS subdomain

### DIFF
--- a/dotgov-websites/other-websites.csv
+++ b/dotgov-websites/other-websites.csv
@@ -17018,3 +17018,4 @@ mail.sss.gov
 rds.sss.gov
 ts.sss.gov
 dmcvpn.sss.gov
+promote.americorps.gov


### PR DESCRIPTION
CNCS has requested that we add promote.americorps.gov so that it shows up in their Trustymail and HTTPS reports. I verified it is not currently being picked up in the sources gathered by double checking for its presence in their report.


