### PR TITLE
Update from 22 Nov 2021

### DIFF
--- a/current-full.csv
+++ b/current-full.csv
@@ -212,6 +212,7 @@ BELOITWI.GOV,City,Non-Federal Agency,City of Beloit,Beloit,WI,(blank)
 BELTONTEXAS.GOV,City,Non-Federal Agency,"City of Belton, TX",Belton,TX,(blank)
 BENBROOK-TX.GOV,City,Non-Federal Agency,City of Benbrook,Benbrook,TX,wcooper@benbrook-tx.gov
 BENDOREGON.GOV,City,Non-Federal Agency,City of Bend,Bend,OR,Cybersecurityteam@bendoregon.gov
+BENNINGTONTOWNSHIPMI.GOV,City,Non-Federal Agency,Bennington Township,Owosso,MI,golakers_spam@charter.net
 BENSALEMPA.GOV,City,Non-Federal Agency,Bensalem Township,Bensalem,PA,(blank)
 BENSONAZ.GOV,City,Non-Federal Agency,City of Benson,Benson,AZ,itsupport@bensonaz.gov
 BENTONCHARTERTOWNSHIP-MI.GOV,City,Non-Federal Agency,Benton Charter Township,Benton Harbor,MI,(blank)
@@ -222,6 +223,7 @@ BERKELEYHEIGHTS.GOV,City,Non-Federal Agency,Township of Berkeley Heights,Berkele
 BERLINCT.GOV,City,Non-Federal Agency,Town of Berlin,Berlin,CT,(blank)
 BERLINMD.GOV,City,Non-Federal Agency,Town of Berlin,Berlin,MD,mbohlen@berlinmd.gov
 BERLINNH.GOV,City,Non-Federal Agency,City of Berlin,Berlin,NH,(blank)
+BERLINTWPMI.GOV,City,Non-Federal Agency,Berlin Township,Ionia,MI,contact@gov365.us
 BERLINVT.GOV,City,Non-Federal Agency,Town of Berlin,Berlin,VT,admin@berlinvt.org
 BERNCO.GOV,City,Non-Federal Agency,Bernalillo County ,Albuquerque,NM,(blank)
 BERRYVILLEAR.GOV,City,Non-Federal Agency,City of Berryville,Berryville,AR,support@skippits.com
@@ -399,6 +401,7 @@ CANFIELD.GOV,City,Non-Federal Agency,City of Canfield,Canfield,OH,(blank)
 CANNONFALLSMN.GOV,City,Non-Federal Agency,City of Cannon Falls,Cannon Falls,MN,(blank)
 CANTONGA.GOV,City,Non-Federal Agency,City of Canton,Canton,GA,(blank)
 CANTONMI.GOV,City,Non-Federal Agency,Canton Township,Canton,MI,(blank)
+CANTONMS.GOV,City,Non-Federal Agency,"City of Canton, MS - Mayor William Truly",Canton,MS,mayortruly@yahoo.com
 CANTONNY.GOV,City,Non-Federal Agency,Village of Canton,Canton,NY,(blank)
 CANTONOHIO.GOV,City,Non-Federal Agency,"City of Canton, Ohio",Canton,OH,(blank)
 CANTONTWP-OH.GOV,City,Non-Federal Agency,"Canton Township Board of Trustees - Stark County, OH",Canton,OH,(blank)
@@ -555,7 +558,7 @@ CITYOFFARMERSVILLE-CA.GOV,City,Non-Federal Agency,City of Farmersville,Farmersvi
 CITYOFFARMINGTON-AR.GOV,City,Non-Federal Agency,city of farmington,Farmington,AR,(blank)
 CITYOFFOLKSTON-GA.GOV,City,Non-Federal Agency,City of Folkston,Folkston,GA,(blank)
 CITYOFFREDERICKMD.GOV,City,Non-Federal Agency,City of Frederick,Frederick,MD,helpdesk@cityoffrederick.com
-CITYOFGAFFNEY-SC.GOV,City,Non-Federal Agency,City of Gaffney,Gaffney,SC,(blank)
+CITYOFGAFFNEY-SC.GOV,City,Non-Federal Agency,City of Gaffney,Gaffney,SC,jcaggiano@cityofgaffney-sc.gov
 CITYOFGALENAPARK-TX.GOV,City,Non-Federal Agency,City of Galena Park,Galena Park,TX,(blank)
 CITYOFGIGHARBORWA.GOV,City,Non-Federal Agency,City of Gig Harbor,Gig Harbor city,WA,domains@cityofgigharbor.net
 CITYOFGIRARDOH.GOV,City,Non-Federal Agency,City of Girard,Girard,OH,office@mrpcoffice.com
@@ -648,6 +651,7 @@ CITYOFSANAUGUSTINETX.GOV,City,Non-Federal Agency,City of San Augustine,San Augus
 CITYOFSANTEECA.GOV,City,Non-Federal Agency,City of Santee,Santee,CA,JCerpa@cityofsanteeca.gov
 CITYOFSARASOTAFL.GOV,City,Non-Federal Agency,City of Sarasota,Sarasota,FL,Payne.Ringling@sarasotafl.gov
 CITYOFSEMMESAL.GOV,City,Non-Federal Agency,City of Semmes,Semmes,AL,(blank)
+CITYOFSENATOBIAMS.GOV,City,Non-Federal Agency,City of Senatobia,Senatobia,MS,infosec@cityofsenatobia.com
 CITYOFSEWARDNE.GOV,City,Non-Federal Agency,City of Seward,Seward,NE,(blank)
 CITYOFSNOQUALMIEWA.GOV,City,Non-Federal Agency,City of Snoqualmie,Snoqualmie,WA,(blank)
 CITYOFSOUTHFULTONGA.GOV,City,Non-Federal Agency,City of South Fulton,Atlanta,GA,service.cby@cityofsouthfultonga.gov
@@ -747,7 +751,7 @@ COMSTOCKMI.GOV,City,Non-Federal Agency,"Charter Township of Comstock, Michigan",
 CONCORDMA.GOV,City,Non-Federal Agency,Town of Concord,Concord,MA,(blank)
 CONCORDNC.GOV,City,Non-Federal Agency,City of Concord,Concord,NC,jarvise@concordnc.gov
 CONCORDNH.GOV,City,Non-Federal Agency,City of Concord,Concord,NH,jsmullen@concordnh.gov
-CONCRETEWA.GOV,City,Non-Federal Agency,Town of Concrete,Concrete,WA,(blank)
+CONCRETEWA.GOV,City,Non-Federal Agency,Town of Concrete,Concrete,WA,thespaminator1@hotmail.com
 CONNEAUTOHIO.GOV,City,Non-Federal Agency,City of Conneaut,Conneaut,OH,(blank)
 CONNERSVILLEIN.GOV,City,Non-Federal Agency,City of Connersville,Connersville,IN,jrpause@gmail.com
 CONOVERNC.GOV,City,Non-Federal Agency,City of Conover,Conover,NC,webmaster@conovernc.gov
@@ -822,7 +826,7 @@ DADECITYFL.GOV,City,Non-Federal Agency,City of Dade City,Dade City,FL,webmaster@
 DAHLONEGA.GOV,City,Non-Federal Agency,City of Dahlonega,Dahlonega,GA,(blank)
 DALHARTTX.GOV,City,Non-Federal Agency,CITY OF DALHART,Dalhart,TX,(blank)
 DALLAS-GA.GOV,City,Non-Federal Agency,"City of Dallas, Georgia",Dallas,GA,(blank)
-DALLAS.GOV,City,Non-Federal Agency,City of Dallas,Dallas,TX,(blank)
+DALLAS.GOV,City,Non-Federal Agency,City of Dallas,Dallas,TX,ITSSecurity@dallascityhall.com
 DALLASCITYHALL-TX.GOV,City,Non-Federal Agency,City of Dallas,Dallas,TX,ITSSecurity@dallascityhall.com
 DALLASGA.GOV,City,Non-Federal Agency,City of Dallas,Dallas,GA,tclark@dallas-ga.gov
 DALLASOR.GOV,City,Non-Federal Agency,City of Dallas,Dallas,OR,(blank)
@@ -896,7 +900,7 @@ DOUGLASMI.GOV,City,Non-Federal Agency,City of Douglas,douglas,MI,rlabombard@ci.d
 DOUGLASVILLEGA.GOV,City,Non-Federal Agency,City of Douglasville,Douglasville,GA,(blank)
 DOVERMA.GOV,City,Non-Federal Agency,Town of Dover,Dover,MA,webmaster@doverma.org
 DRACUTMA.GOV,City,Non-Federal Agency,Town of Dracut,Dracut,MA,(blank)
-DRAPERUTAH.GOV,City,Non-Federal Agency,Draper City,Draper,UT,britnee.johnston@draper.ut.us
+DRAPERUTAH.GOV,City,Non-Federal Agency,Draper City,Draper,UT,jake.sorensen@draperutah.gov
 DRUIDHILLSKY.GOV,City,Non-Federal Agency,"City of Druid Hills, KY",Louisville,KY,(blank)
 DUBLIN-CA.GOV,City,Non-Federal Agency,City of Dublin,Dublin,CA,is@dublin.ca.gov
 DUBLINCA.GOV,City,Non-Federal Agency,City of Dublin,Dublin,CA,is@dublin.ca.gov
@@ -1022,6 +1026,7 @@ EUGENE-OR.GOV,City,Non-Federal Agency,City of Eugene ISD,Eugene,OR,(blank)
 EULESSTX.GOV,City,Non-Federal Agency,"City of Euless, TX",Euless,TX,sjoyce@eulesstx.gov
 EUREKA-MT.GOV,City,Non-Federal Agency,Town of Eureka,Eureka,MT,(blank)
 EUREKASPRINGSAR.GOV,City,Non-Federal Agency,Eureka Springs Police Department,Eureka Springs,AR,(blank)
+EUREKATOWNSHIPMI.GOV,City,Non-Federal Agency,Eureka Township,Greenville,MI,kps@shumakergroup.com
 EUTAWAL.GOV,City,Non-Federal Agency,City of Eutaw,Eutaw,AL,it@eutawal.org
 EVANSCOLORADO.GOV,City,Non-Federal Agency,City of Evans Colorado,Evans,CO,IT@evanscolorado.gov
 EVANSTON-WY.GOV,City,Non-Federal Agency,CITY OF EVANSTON,EVANSTON,WY,(blank)
@@ -1400,6 +1405,7 @@ HOLLYSPRINGSMS.GOV,City,Non-Federal Agency,City Of Holly Springs ,Holly Springs,
 HOLLYSPRINGSNC.GOV,City,Non-Federal Agency,Town of Holly Springs,Holly Springs,NC,itsupport@hollyspringsnc.us
 HOLLYWOODPARK-TX.GOV,City,Non-Federal Agency,Town of Hollywood Park,Hollywood Park,TX,(blank)
 HOMERGLENIL.GOV,City,Non-Federal Agency,Village of Homer Glen,Homer Glen,IL,(blank)
+HOMESTEADTWPMI.GOV,City,Non-Federal Agency,Homestead Township,Honor,MI,supervisor@homesteadtwp.com
 HOMEWOODIL.GOV,City,Non-Federal Agency,Village of Homewood,Homewood,IL,(blank)
 HONDO-TX.GOV,City,Non-Federal Agency,City of Hondo,Hondo,TX,(blank)
 HONESDALEPD-PA.GOV,City,Non-Federal Agency,Honesdale Police Department,Honesdale,PA,chris@marshallconsulting.biz
@@ -1433,6 +1439,7 @@ HUNTSVILLEAL.GOV,City,Non-Federal Agency,City of Huntsville,Huntsville,AL,gene.u
 HUNTSVILLEALTRANSIT.GOV,City,Non-Federal Agency,City of Huntsville,Huntsville,AL,gregory.danehower@huntsvilleal.gov
 HUNTSVILLETX.GOV,City,Non-Federal Agency,City of Huntsville,Huntsville,TX,(blank)
 HURLOCK-MD.GOV,City,Non-Federal Agency,Town of Hurlock,Hurlock,MD,(blank)
+HURONSD.GOV,City,Non-Federal Agency,City of Huron,Huron,SD,alert.it@huronsd.com
 HURONTOWNSHIP-MI.GOV,City,Non-Federal Agency,Huron Township,New Boston,MI,jcady@hurontownship-mi.gov
 HURSTTX.GOV,City,Non-Federal Agency,City of Hurst,Hurst,TX,spatel@hursttxx.gov
 HUTCHINSONMN.GOV,City,Non-Federal Agency,City of Hutchinson,Hutchinson,MN,tkloss@ci.hutchinson.mn.us
@@ -1466,7 +1473,7 @@ IPSWICH-MA.GOV,City,Non-Federal Agency,Town of Ipswich,Ipswich,MA,mis@ipswichma.
 IPSWICHMA.GOV,City,Non-Federal Agency,Town of Ipswich,Ipswich,MA,mis@ipswichma.gov
 IRONDEQUOIT.GOV,City,Non-Federal Agency,Town of Irondequoit,Rochester,NY,it@irondequoit.org
 IRONTONMO.GOV,City,Non-Federal Agency,City of Ironton,Ironton,MO,(blank)
-IRVINECA.GOV,City,Non-Federal Agency,City of Irvine,Irvine,CA,(blank)
+IRVINECA.GOV,City,Non-Federal Agency,City of Irvine,Irvine,CA,TChiu@cityofirvine.org
 IRVINGTONNY.GOV,City,Non-Federal Agency,Village of Irvington,Irvington,NY,office@irvingtonny.gov
 IRWINDALECA.GOV,City,Non-Federal Agency,City of Irwindale,Irwindale,CA,jwagner@irwindaleca.gov
 ISLANDHEIGHTSBOROUGH.GOV,City,Non-Federal Agency,Borough of Island Heights,Island Heights,NJ,clerkislandheights@gmail.com
@@ -2034,6 +2041,7 @@ NEWCHICAGOIN.GOV,City,Non-Federal Agency,Town of New Chicago,Hobart,IN,(blank)
 NEWCOMBNY.GOV,City,Non-Federal Agency,Town of Newcomb,Newcomb,NY,domain@newcombny.com
 NEWCONCORD-OH.GOV,City,Non-Federal Agency,Village of New Concord,New Concord,OH,lmarlatt@newconcord-oh.gov
 NEWFIELDSNH.GOV,City,Non-Federal Agency,Town of Newfields,Newfields,NH,(blank)
+NEWGLARUSVILLAGEWI.GOV,City,Non-Federal Agency,Village of New Glarus,New Glarus,WI,security@newglarusvillagewi.gov
 NEWHARMONY-IN.GOV,City,Non-Federal Agency,Town of New Harmony,New Harmony,IN,karla_atkins@att.net
 NEWHARTFORDCT.GOV,City,Non-Federal Agency,Town of New Hartford,New Hartford,CT,(blank)
 NEWHAVENCT.GOV,City,Non-Federal Agency,City of New Haven Connecticut,New Haven,CT,(blank)
@@ -2042,7 +2050,7 @@ NEWHOPETX.GOV,City,Non-Federal Agency,Town of New Hope,New Hope,TX,(blank)
 NEWINGTONCT.GOV,City,Non-Federal Agency,Town of Newington,Newington,CT,security@newingtonct.gov
 NEWLEXINGTONOHIO.GOV,City,Non-Federal Agency,Village of New Lexington,New Lexington,OH,finance@newlexingtonohio.gov
 NEWLONDONWI.GOV,City,Non-Federal Agency,City of New London WI,New London,WI,(blank)
-NEWMARKETNH.GOV,City,Non-Federal Agency,Town of Newmarket,Newmarket,NH,(blank)
+NEWMARKETNH.GOV,City,Non-Federal Agency,Town of Newmarket,Newmarket,NH,support@bbnnh.com
 NEWMARLBOROUGHMA.GOV,City,Non-Federal Agency,Town of New Marlborough,Mill River,MA,(blank)
 NEWMILFORDCT.GOV,City,Non-Federal Agency,Town of New Milford,New Milford,CT,it@newmilford.org
 NEWNANGA.GOV,City,Non-Federal Agency,"City of Newnan, Georgria",Newnan,GA,(blank)
@@ -2118,6 +2126,7 @@ NORTHHEMPSTEADNY.GOV,City,Non-Federal Agency,TOWN OF NORTH HEMPSTEAD,MANHASSET,N
 NORTHLEBANONTWPPA.GOV,City,Non-Federal Agency,North Lebanon Township,Lebanon,PA,(blank)
 NORTHMIAMIFL.GOV,City,Non-Federal Agency,City of North Miami,North Miami,FL,(blank)
 NORTHOAKSMN.GOV,City,Non-Federal Agency,City of North Oaks,North Oaks,MN,kkress@cityofnorthoaks.com
+NORTHPLAINFIELD-NJ.GOV,City,Non-Federal Agency,North Plainfield Borough,North Plainfield,NJ,amckay@npmail.org
 NORTHPORTFL.GOV,City,Non-Federal Agency,City of North Port,North Port,FL,abourquin@cityofnorthport.com
 NORTHPORTNY.GOV,City,Non-Federal Agency,"Incorporated Village of Northport, NY",Northport,NY,s.costello@northportny.gov
 NORTHPROVIDENCERI.GOV,City,Non-Federal Agency,Town of North Providence ,North Providence,RI,(blank)
@@ -2165,6 +2174,7 @@ ODESSA-TX.GOV,City,Non-Federal Agency,City of Odessa,Odessa,TX,webmaster@odessa-
 OFALLONIL.GOV,City,Non-Federal Agency,"City of O'Fallon, Illinois",O'Fallon,IL,admin@ofallon.org
 OGALLALA-NE.GOV,City,Non-Federal Agency,City of Ogallala,Ogallala,NE,mark.skinner@ogallala-ne.gov
 OGDEN-KS.GOV,City,Non-Federal Agency,City of Ogden,Ogden ,KS,(blank)
+OGUNQUIT.GOV,City,Non-Federal Agency,Town of Ogunquit,Ogunquit,ME,townmanager@townofogunquit.org
 OKC.GOV,City,Non-Federal Agency,City Of Oklahoma City,Oklahoma City,OK,it-security@okc.gov
 OKEMAHOK.GOV,City,Non-Federal Agency,City of Okemah,Okemah,OK,chiefofpolice@okemahok.org
 OLATHEKS.GOV,City,Non-Federal Agency,City of Olathe,Olathe,KS,(blank)
@@ -2189,7 +2199,7 @@ ORLANDOFL.GOV,City,Non-Federal Agency,City of Orlando,Orlando,FL,(blank)
 ORONOCOTOWNSHIP-MN.GOV,City,Non-Federal Agency,Oronoco Township,Oronoco,MN,(blank)
 OROVALLEYAZ.GOV,City,Non-Federal Agency,Town of Oro Valley,Oro Valley,AZ,(blank)
 ORWIGSBURG.GOV,City,Non-Federal Agency,Borough of Orwigsburg,Orwigsburg,PA,cyorski@orwigsburg.gov
-OSAGEBEACH-MO.GOV,City,Non-Federal Agency,CITY OF OSAGE BEACH,OSAGE BEACH,MO,mwelty@osagebeach.org
+OSAGEBEACH-MO.GOV,City,Non-Federal Agency,CITY OF OSAGE BEACH,OSAGE BEACH,MO,mbean@osagebeach.org
 OSCODATOWNSHIPMI.GOV,City,Non-Federal Agency,Charter Township of Oscoda,Oscoda,MI,admin@oscodatownshipmi.gov
 OSSIPEE-NH.GOV,City,Non-Federal Agency,Ossipee Police Department,Ossipee,NH,acastaldo@ossipee.org
 OSWEGOIL.GOV,City,Non-Federal Agency,Village of Oswego,Oswego,IL,jrenzetti@oswegoil.org
@@ -2258,7 +2268,7 @@ PERRY-GA.GOV,City,Non-Federal Agency,City of Perry,Perry,GA,(blank)
 PERRY-WI.GOV,City,Non-Federal Agency,Town of Perry,Mount Horeb,WI,(blank)
 PERRYSBURGOH.GOV,City,Non-Federal Agency,City of Perrysburg,Perrysburg,OH,(blank)
 PERRYTOWNSHIP-IN.GOV,City,Non-Federal Agency,Perry Township ,Indianapolis,IN,gcox@diversetechservices.com
-PETAL-MS.GOV,City,Non-Federal Agency,City of Petal,Petal,MS,info@jensencomputers.net
+PETAL-MS.GOV,City,Non-Federal Agency,City of Petal,Petal,MS,mmartin@cityofpetal.com
 PETERBOROUGHNH.GOV,City,Non-Federal Agency,Town of Peterborough,Peterborough,NH,itservices@peterboroughnh.gov
 PETERSBURGAK.GOV,City,Non-Federal Agency,"Petersburg Borough, Alaska",Petersburg,AK,(blank)
 PETERSBURGMI.GOV,City,Non-Federal Agency,City of Petersburg,PETERSBURG,MI,terri@cass.net
@@ -2505,6 +2515,7 @@ RRNM.GOV,City,Non-Federal Agency,City of Rio Rancho,Rio Rancho,NM,(blank)
 RUIDOSO-NM.GOV,City,Non-Federal Agency,Village of Ruidoso,Ruidoso,NM,(blank)
 RUMSONNJ.GOV,City,Non-Federal Agency,The Borough of Rumson,Rumson,NJ,trogers@rumsonnj.gov
 RUSSELLSPOINT-OH.GOV,City,Non-Federal Agency,Village of Russells Point,Russells Point,OH,(blank)
+RUSTONLA.GOV,City,Non-Federal Agency,City of Ruston,Ruston,LA,dhampton@ruston.org
 RVA.GOV,City,Non-Federal Agency,City of Richmond,Richmond,VA,DIT-WintelSystemEngineers@richmondgov.com
 RVCNY.GOV,City,Non-Federal Agency,Village of Rockville Centre,Rockville Centre,NY,(blank)
 RYENY.GOV,City,Non-Federal Agency,City of Rye,Rye,NY,(blank)
@@ -2533,6 +2544,7 @@ SANDIEGO.GOV,City,Non-Federal Agency,The City of San Diego,San Diego,CA,cybersec
 SANDIMASCA.GOV,City,Non-Federal Agency,City of San Dimas,San Dimas,CA,administration@ci.san-dimas.ca.us
 SANDISFIELDMA.GOV,City,Non-Federal Agency,Town of Sandisfield,Sandisfield,MA,(blank)
 SANDPOINTIDAHO.GOV,City,Non-Federal Agency,City of Sandpoint,Sandpoint,ID,support@exbabylon.com
+SANDSPOINT.GOV,City,Non-Federal Agency,Inc Village of Sands Point,Sands Point,NY,it@sandspoint.org
 SANDYSPRINGSGA.GOV,City,Non-Federal Agency,City of Sandy Springs,Sandy Springs,GA,servicedesk@sandyspringsga.gov
 SANDYSPRINGSGAPOLICE.GOV,City,Non-Federal Agency,Sandy Springs Police Department,Sandy Springs,GA,ron@brunerandcompany.com
 SANFORDFL.GOV,City,Non-Federal Agency,City Of Sanford,Sanford,FL,(blank)
@@ -2679,7 +2691,7 @@ SOUTHMIAMIPDFL.GOV,City,Non-Federal Agency,City of South Miami,South Miami,FL,(b
 SOUTHOGDENCITY.GOV,City,Non-Federal Agency,South Ogden City,South Ogden,UT,security@southogdencity.gov
 SOUTHOLDTOWNNY.GOV,City,Non-Federal Agency,Town of Southold,Southold,NY,(blank)
 SOUTHPASADENACA.GOV,City,Non-Federal Agency,City of South Pasadena,South Pasadena,CA,(blank)
-SOUTHPITTSBURG-TN.GOV,City,Non-Federal Agency,City of South Pittsburg,South Pittsburg,TN,(blank)
+SOUTHPITTSBURG-TN.GOV,City,Non-Federal Agency,City of South Pittsburg,South Pittsburg,TN,hpickett@southpittsburg-tn.gov
 SOUTHSANFRANCISCOCA.GOV,City,Non-Federal Agency,City of South San Francisco,South San Francisco,CA,(blank)
 SOUTHTUCSONAZ.GOV,City,Non-Federal Agency,City of South Tucson,South Tucson,AZ,laguirre@southtucson.org
 SOUTHWINDSOR-CT.GOV,City,Non-Federal Agency,Town of South Windsor,South Windsor,CT,(blank)
@@ -2890,10 +2902,12 @@ TOWNOFKEENENY.GOV,City,Non-Federal Agency,Town of Keene NY,Keene,NY,lturbini@co.
 TOWNOFKENTNY.GOV,City,Non-Federal Agency,Town of Kent,Kent Lakes,NY,(blank)
 TOWNOFKERSHAWSC.GOV,City,Non-Federal Agency,Town of Kershaw,Kershaw,SC,(blank)
 TOWNOFKIOWA-CO.GOV,City,Non-Federal Agency,Town of Kiowa,Kiowa,CO,mmorales@townofkiowa.com
+TOWNOFLANDISNC.GOV,City,Non-Federal Agency,Town of Landis,Landis,NC,rpowell@townoflandis.com
 TOWNOFLAPOINTEWI.GOV,City,Non-Federal Agency,Town of La Pointe,La Pointe,WI,(blank)
 TOWNOFLAVETA-CO.GOV,City,Non-Federal Agency,Town of La Veta,La Veta,CO,(blank)
 TOWNOFLEBANONNY.GOV,City,Non-Federal Agency,Town of Lebanon,Earlville,NY,John.mackenzie@montellocs.com
 TOWNOFLEBANONWI.GOV,City,Non-Federal Agency,Town of Lebanon,New London,WI,townoflebanon@gmail.com
+TOWNOFLUSKWY.GOV,City,Non-Federal Agency,Town of Lusk,Lusk,WY,office@townoflusk.org
 TOWNOFLYNDONWI.GOV,City,Non-Federal Agency,TOWN OF LYNDON,LYNDON STATION,WI,support@kerberrose.com
 TOWNOFMAYNARD-MA.GOV,City,Non-Federal Agency,Town of Maynard,Maynard,MA,(blank)
 TOWNOFMILTONWI.GOV,City,Non-Federal Agency,Town of Milton,Fountain City,WI,ben.adank@gmail.com
@@ -3279,6 +3293,7 @@ ZIONSVILLE-IN.GOV,City,Non-Federal Agency,Town of Zionsville,Zionsville,IN,jrust
 ABBEVILLECOUNTYSC.GOV,County,Non-Federal Agency,Abbeville County,Abbeville,SC,rocky@abbevillecountysc.com
 ADAMSCOUNTYIL.GOV,County,Non-Federal Agency,"Adams County, IL",Quincy,IL,dhochgraber@co.adams.il.us
 ADAMSCOUNTYMS.GOV,County,Non-Federal Agency,Adams County Board of Supervisors,Natchez,MS,(blank)
+ADAMSCOUNTYNE.GOV,County,Non-Federal Agency,ADAMS COUNTY NEBRASKA,HASTINGS,NE,rkucera@adamscounty.org
 ADAMSCOUNTYOH.GOV,County,Non-Federal Agency,Adams County Commissioners,West Union,OH,(blank)
 ADAMSCOUNTYPA.GOV,County,Non-Federal Agency,County of Adams,Gettysburg,PA,abuse@adamscounty.us
 AIKENCOUNTYSC.GOV,County,Non-Federal Agency,Aiken County Government,Aiken,SC,(blank)
@@ -3324,6 +3339,7 @@ BAKERCOUNTYSHERIFFOR.GOV,County,Non-Federal Agency,baker county,Baker City,OR,bl
 BALDWINCOUNTYAL.GOV,County,Non-Federal Agency,Baldwin County Commission,Bay Minette,AL,(blank)
 BALTIMORECOUNTYMD.GOV,County,Non-Federal Agency,"Baltimore County, Maryland ",Towson,MD,(blank)
 BAMBERGCOUNTYSC.GOV,County,Non-Federal Agency,Bamberg County Government,Bamberg,SC,thomastm@bambercounty.sc.gov
+BANNERCOUNTYNE.GOV,County,Non-Federal Agency,Banner County,Harrisburg,NE,cio.help@nebraska.gov
 BANNOCKCOUNTYIDAHO.GOV,County,Non-Federal Agency,Bannock County,Pocatello,ID,dp@bannockcounty.us
 BARNSTABLECOUNTY-MA.GOV,County,Non-Federal Agency,Barnstable County,Barnstable,MA,security@barnstablecounty.org
 BARRONCOUNTYWI.GOV,County,Non-Federal Agency,Barron County,Barron,WI,technology@co.barron.wi.us
@@ -3408,6 +3424,7 @@ CALHOUNCOUNTYAL.GOV,County,Non-Federal Agency,Calhoun County Commission,Anniston
 CALHOUNCOUNTYFLSHERIFF.GOV,County,Non-Federal Agency,Calhoun County Sheriff's Office,Blountstown,FL,juliocmayorga@compunettechnicalservices.com
 CALHOUNCOUNTYMI.GOV,County,Non-Federal Agency,"Calhoun County, Michigan",Marshall,MI,(blank)
 CALLOWAYCOUNTY-KY.GOV,County,Non-Federal Agency,Calloway County Judge Executive,Murray,KY,(blank)
+CALUMETCOUNTY.GOV,County,Non-Federal Agency,Calumet County,Chilton,WI,abuse@calumetcounty.org
 CALVERTCOUNTYMD.GOV,County,Non-Federal Agency,Calvert County Board of County Commissioners,Prince Frederick,MD,network@calvertcountymd.gov
 CAMBRIACOUNTYPA.GOV,County,Non-Federal Agency,Cambria County,Ebensburg,PA,(blank)
 CAMDENCOUNTYGA.GOV,County,Non-Federal Agency,Camden County Board of Commissioners,Woodbine,GA,lfoltzer@co.camden.ga.us
@@ -3481,7 +3498,7 @@ CLARKCOUNTYWI.GOV,County,Non-Federal Agency,Clark County Wisconsin,Neillsville,W
 CLARKECOUNTY.GOV,County,Non-Federal Agency,Clarke County Government,Berryville,VA,(blank)
 CLARKECOUNTYMS.GOV,County,Non-Federal Agency,Clarke County Mississippi Board of Supervisors,Quitman,MS,(blank)
 CLAYCOUNTYIN.GOV,County,Non-Federal Agency,Clay County Courthouse,Brazil,IN,hillsc@claycountyin.gov
-CLAYCOUNTYMN.GOV,County,Non-Federal Agency,Clay County,Moorhead,MN,sysadmin@co.clay.mn.us
+CLAYCOUNTYMN.GOV,County,Non-Federal Agency,Clay County,Moorhead,MN,sysadmin@claycountymn.gov
 CLAYCOUNTYMO.GOV,County,Non-Federal Agency,"Clay County, Missouri",Liberty,MO,networksupport@claycountymo.gov
 CLAYCOUNTYNE.GOV,County,Non-Federal Agency,Clay County Nebraska,Clay Center,NE,help@myprecisionit.com
 CLAYELECTIONS.GOV,County,Non-Federal Agency,Clay County Supervisor of Elections,Green Cove Springs,FL,JKrause@ClayElections.com
@@ -3601,7 +3618,7 @@ FAIRFAXCOUNTYVA.GOV,County,Non-Federal Agency,Fairfax County Government,Fairfax,
 FAIRFAXCOUNTYVIRGINIA.GOV,County,Non-Federal Agency,Fairfax County Government,Fairfax,VA,(blank)
 FAIRFIELDCOUNTYOHIO.GOV,County,Non-Federal Agency,Fairfield County,Lancaster,OH,(blank)
 FAIRFIELDCOUNTYOHIOELECTIONS.GOV,County,Non-Federal Agency,Fairfield County,Lancaster,OH,jay.mattlin@fairfieldcountyohio.gov
-FAIRFIELDCOUNTYOHIOWORKFORCECENTER.GOV,County,Non-Federal Agency,Fairfield County,Lancaster,OH,mark.conrad@fairfieldcountyohio.gov
+FAIRFIELDCOUNTYOHIOWORKFORCECENTER.GOV,County,Non-Federal Agency,Fairfield County,Lancaster,OH,brian.plummer@fairfieldcountyohio.gov
 FAULKNERCOUNTYAR.GOV,County,Non-Federal Agency,Faulkner County Arkansas,Conway,AR,SUPPORT@FAULKNERCOUNTY.ORG
 FAUQUIERCOUNTY.GOV,County,Non-Federal Agency,Fauquier County Government,Warrenton,VA,(blank)
 FAYETTECOUNTYGA.GOV,County,Non-Federal Agency,Fayette County Board of Commissioners,Fayetteville,GA,(blank)
@@ -3656,13 +3673,14 @@ GILMERCOUNTYWV.GOV,County,Non-Federal Agency,GILMER COUNTY COMMISSION,GLENVILLE,
 GLADWINCOUNTY-MI.GOV,County,Non-Federal Agency,Gladwin County,Gladwin,MI,(blank)
 GLOUCESTERCOUNTYNJ.GOV,County,Non-Federal Agency,County of Gloucester,Woodbury,NJ,dmarc@co.gloucester.nj.us
 GLYNNCOUNTY-GA.GOV,County,Non-Federal Agency,Glynn County Board of Commissioners,Brunswick,GA,dbragdon@glynncounty-ga.gov
+GOGEBIC.GOV,County,Non-Federal Agency,Gogebic County,Bessemer,MI,(blank)
 GOGEBICCOUNTYMI.GOV,County,Non-Federal Agency,Gogebic County,Bessemer,MI,(blank)
 GOLIADCOUNTYTX.GOV,County,Non-Federal Agency,Goliad County,Goliad,TX,(blank)
 GOODHUECOUNTYMN.GOV,County,Non-Federal Agency,"Goodhue County, MN",Red Wing,MN,gc_it@co.goodhue.mn.us
 GRADYCOUNTYGA.GOV,County,Non-Federal Agency,Grady County Board of Commissioners,Cairo,GA,bjohnson@gradyco.org
 GRAINGERCOUNTYTN.GOV,County,Non-Federal Agency,Tennessee,Rutledge,TN,(blank)
 GRANTCOUNTY-OR.GOV,County,Non-Federal Agency,Grant County Court,Canyon City,OR,(blank)
-GRANTCOUNTYNM.GOV,County,Non-Federal Agency,Grant County,Silver City,NM,dmiranda@grantcountynm.gov
+GRANTCOUNTYNM.GOV,County,Non-Federal Agency,Grant County,Silver City,NM,abaca@grantcountynm.gov
 GRANTCOUNTYWA.GOV,County,Non-Federal Agency,Grant County,Ephrata,WA,gcts@grantcountywa.gov
 GRAVESCOUNTYKY.GOV,County,Non-Federal Agency,Graves County Fiscal Court,Mayfield,KY,judgejperry@hotmail.com
 GRAYSONCOUNTYKY.GOV,County,Non-Federal Agency,Grayson County Judge Executive ,Leitchfield,KY,emmettdesignsllc@gmail.com
@@ -3844,6 +3862,7 @@ LEBANONCOUNTYPA.GOV,County,Non-Federal Agency,Lebanon County,Lebanon,PA,itssecur
 LEE-COUNTY-FL.GOV,County,Non-Federal Agency,Lee County Government,Fort Myers,FL,komalley@leegov.com
 LEECOUNTYNC.GOV,County,Non-Federal Agency,Lee County Government,Sanford,NC,admin@leecountync.gov
 LEELANAU.GOV,County,Non-Federal Agency,Leelanau County,Suttons Bay,MI,rplamondon@leelanau.gov
+LEHIGHCOUNTYPA.GOV,County,Non-Federal Agency,County of Lehigh,Allentown,PA,InformationSecurity@lehighcounty.org
 LENOIRCOUNTYNC.GOV,County,Non-Federal Agency,Lenoir County,Kinston,NC,security@co.lenoir.nc.us
 LEONCOUNTYFL.GOV,County,Non-Federal Agency,Leon County Board of County Commissioners,Tallahassee,FL,russella@leoncountyfl.gov
 LEONVOTES.GOV,County,Non-Federal Agency,Supervisor of Elections,Tallahassee,FL,TJ@leoncountyfl.gov
@@ -4000,6 +4019,7 @@ NASSAUCOUNTYNY.GOV,County,Non-Federal Agency,Nassau County,Mineola,NY,(blank)
 NATRONACOUNTY-WY.GOV,County,Non-Federal Agency,Natrona County,Casper,WY,security@natronacounty-wy.gov
 NAVAJOCOUNTYAZ.GOV,County,Non-Federal Agency,Navajo County,Holbrook,AZ,security@navajocountyaz.gov
 NELSONCOUNTY-VA.GOV,County,Non-Federal Agency,Nelson County,Lovingston,VA,(blank)
+NEMAHACOUNTYNE.GOV,County,Non-Federal Agency,Nemaha County,Auburn,NE,(blank)
 NEWAYGOCOUNTYMI.GOV,County,Non-Federal Agency,County of Newaygo,White Cloud,MI,abuse@co.newaygo.mi.us
 NEWCASTLEDE.GOV,County,Non-Federal Agency,New Castle County Governement,New Castle,DE,(blank)
 NEWTONCOUNTYMO.GOV,County,Non-Federal Agency,Newton County,Neosho,MO,security@newtoncountymo.gov
@@ -4122,6 +4142,7 @@ READYALBANYCOUNTY-NY.GOV,County,Non-Federal Agency,Albany County,Albany,NY,(blan
 READYMCHENRYCOUNTYIL.GOV,County,Non-Federal Agency,McHenry County Government Center,Woodstock,IL,(blank)
 READYMCHENRYCOUNTYILLINOIS.GOV,County,Non-Federal Agency,McHenry County Government Center,Woodstock,IL,(blank)
 REDWILLOWCOUNTYNE.GOV,County,Non-Federal Agency,Red Willow County,McCook,NE,eknott@appliedconnective.com
+RENVILLECOUNTYMN.GOV,County,Non-Federal Agency,RenvilleCounty,Olivia,MN,it@renvillecountymn.com
 RESUMEMCHENRYCOUNTYIL.GOV,County,Non-Federal Agency,County of McHenry,Woodstock,IL,trpatenaude@mchenrycountyil.gov
 REYNOLDSCOUNTY-MO.GOV,County,Non-Federal Agency,Reynolds County,Centerville,MO,(blank)
 RHEACOUNTYTN.GOV,County,Non-Federal Agency,Rhea County Sheriff's Department,Dayton,TN,(blank)
@@ -4196,7 +4217,7 @@ SHERIFFMIAMICOUNTYKS.GOV,County,Non-Federal Agency,Miami County Sheriff's Office
 SHERIFFWASHINGTONCOUNTYMAINE.GOV,County,Non-Federal Agency,Washington County Sheriff's Office,Machias,ME,dorseyd@wcsheriffsoffice.com
 SHERMANCOUNTYKS.GOV,County,Non-Federal Agency,County of Sherman,Goodland,KS,(blank)
 SIMPSONCOUNTYKY.GOV,County,Non-Federal Agency,Simpson County Fiscal Court,Franklin,KY,itnotify@simpsoncounty.us
-SIOUXCOUNTYIA.GOV,County,Non-Federal Agency,Sioux County,Orange City,IA,security@siouxcounty.org
+SIOUXCOUNTYIA.GOV,County,Non-Federal Agency,Sioux County,Orange City,IA,tech@siouxcounty.org
 SJBPARISH.GOV,County,Non-Federal Agency,St. John the Baptist Parish,LaPlace,LA,ParishIT@stjohn-la.gov
 SKAGITCOUNTYWA.GOV,County,Non-Federal Agency,Skagit County Government,Mount Vernon,WA,(blank)
 SLOPECOUNTYND.GOV,County,Non-Federal Agency,Slope County,Amidon,ND,mrmedora@hotmail.com
@@ -4272,6 +4293,7 @@ TEXASCOUNTYMISSOURI.GOV,County,Non-Federal Agency,Texas County Missouri,Houston,
 THAYERCOUNTYNE.GOV,County,Non-Federal Agency,Thayer County Courthouse,Hebron,NE,support@appliedconnective.com
 THOMASCOUNTYGA.GOV,County,Non-Federal Agency,Thomas County Board of Commissioners,Thomasville,GA,(blank)
 THOMASCOUNTYKS.GOV,County,Non-Federal Agency,Thomas County,Colby,KS,(blank)
+THURSTONCOUNTYSHERIFFNE.GOV,County,Non-Federal Agency,Thurston County Sheriff's Office,Pender,NE,thurstonso22@gmail.com
 THURSTONCOUNTYWA.GOV,County,Non-Federal Agency,"Thurston County, WA",Olympia,WA,Security_reviews@co.thurston.wa.us
 TILLAMOOKCOUNTY.GOV,County,Non-Federal Agency,Tillamook County,TILLAMOOK,OR,dp@co.tillamook.or.us
 TIOGACOUNTYNY.GOV,County,Non-Federal Agency,Tioga County,Owego,NY,helpdesk@co.tioga.ny.us
@@ -5705,6 +5727,7 @@ ACCESSOH.GOV,Independent Intrastate Agency,Non-Federal Agency,ACCESS Council,Boa
 ARTRANSPARENCY.GOV,Independent Intrastate Agency,Non-Federal Agency,Association of Arkansas Counties,Little Rock,AR,mharrell@arcounties.org
 AZRANGERS.GOV,Independent Intrastate Agency,Non-Federal Agency,Arizona Rangers,Mesa,AZ,webmaster@azrangers.us
 BAAQMD.GOV,Independent Intrastate Agency,Non-Federal Agency,Bay Area Air Quality Management District,San Francisco,CA,security@baaqmd.gov
+BANNINGLIBRARYCA.GOV,Independent Intrastate Agency,Non-Federal Agency,Banning Library District,Banning,CA,kevin@banninglibrarydistrict.org
 BLOCKHOUSEMUDTX.GOV,Independent Intrastate Agency,Non-Federal Agency,Block House Municipal Utility,Leander,TX,jsmith@crossroadsus.com
 BRIDGERCANYONFIREMT.GOV,Independent Intrastate Agency,Non-Federal Agency,BRIDGER CANYON FIRE DEPARTMENT,BOZEMAN,MT,tmather@bridgercanyonfiremt.gov
 CAL-ITP.GOV,Independent Intrastate Agency,Non-Federal Agency,Capitol Corridor Joint Powers Authority,Oakland,CA,info@capitolcorridor.org
@@ -5737,6 +5760,7 @@ JEMS-IL.GOV,Independent Intrastate Agency,Non-Federal Agency,Northwest Central J
 LAWRENCECOUNTYMO911.GOV,Independent Intrastate Agency,Non-Federal Agency,Lawrence County Emergency Services Board 9-1-1,Mt. Vernon,MO,911emamonettlawco@cityofmonett.com
 LCEMSAMI.GOV,Independent Intrastate Agency,Non-Federal Agency,Lake Charlevoix Emergency Service Authority,Charlevoix,MI,domainadmin@charlevoixmi.gov
 LCFWASA.GOV,Independent Intrastate Agency,Non-Federal Agency,Lower Cape Fear Water and Sewer Authority,Leland,NC,security@lcfwasa.org
+LEONPA.GOV,Independent Intrastate Agency,Non-Federal Agency,Leon County Property Appraiser,Tallahassee,FL,itdept2@leonpa.org
 LPCD-LAFLA.GOV,Independent Intrastate Agency,Non-Federal Agency,LAFAYETTE PARISH COMMUNICATION DISTRICT,LAFAYETTE,LA,jthompson@lafayettela.gov
 LPCDOPS-LAFLA.GOV,Independent Intrastate Agency,Non-Federal Agency,LAFAYETTE PARISH COMMUNICATION DISTRICT,LAFAYETTE,LA,jthompson@lafayettela.gov
 MANATEEPAO.GOV,Independent Intrastate Agency,Non-Federal Agency,Manatee County Property Appraiser,Bradenton,FL,paoit@manateepao.com
@@ -5974,7 +5998,7 @@ SHAWNEE-NSN.GOV,Native Sovereign Nation,Indian Affairs,The Shawnee Tribe,Miami,O
 SHOALWATERBAY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Shoalwater Bay indian Tribe,Tokeland,WA,(blank)
 SIR-NSN.GOV,Native Sovereign Nation,Indian Affairs,Susanville Indian Rancheria,Susanville,CA,kcapistrand@sir-nsn.gov
 SITKATRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sitka Tribe of Alaska,Sitka,AK,(blank)
-SNO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Seminole Nation of Oklahoma,Wewoka,OK,(blank)
+SNO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Seminole Nation of Oklahoma,Wewoka,OK,bear.a@sno-nsn.gov
 SOBOBA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Soboba Band of Luiseno Indians,San Jacinto,CA,snino@soboba-nsn.gov
 SOUTHERNUTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,SOUTHERN UTE INDIAN TRIBE,IGNACIO,CO,su_netadmins@southernute.com
 SRMT-NSN.GOV,Native Sovereign Nation,Indian Affairs,St Regis Mohawk Tribe,Akwesasne,NY,(blank)
@@ -6016,6 +6040,8 @@ YDSP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ysleta Del Sur Pueblo,El Pas
 YOCHADEHE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Yocha Dehe Wintun Nation,Brooks,CA,(blank)
 YPT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Yerington Paiute Tribe,Yerington,NV,ittech@ypt-nsn.gov
 AKIAKIRA-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Akiak Native Community,Akiak,AK,shamer@akiaktechnology.com
+BVR-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Big Valley Rancheria,Lakeport,CA,noc@big-valley.net
+GTB-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Grand Traverse Band of Ottawa and Chippewa Indians,Peshawbestown,MI,itsupport@gtbindians.com
 IIPAYNATIONOFSANTAYSABEL-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Iipay Nation of Santa Ysabel,Santa Ysabel,CA,tribalcouncil@iipaynation-nsn.gov
 NHBP.GOV,Native Sovereign Nation,Non-Federal Agency,Nottawaseppi Huron Band of the Potawatomi,Fulton,MI,it@nhbp-nsn.gov
 TBYI.GOV,Native Sovereign Nation,Non-Federal Agency,Texas Band of Yaqui Indians,Lubbock,TX,vicechairmantexasyaqui@gmail.com
@@ -6097,13 +6123,12 @@ AZASRS.GOV,State,Non-Federal Agency,Arizona State Retirement System,Phoenix,AZ,d
 AZAUDITOR.GOV,State,Non-Federal Agency,"State of Arizona, Office of the Auditor General",Phoenix,AZ,itsec@azauditor.gov
 AZBN.GOV,State,Non-Federal Agency,Arizona State Board of Nursing,Phoenix,AZ,(blank)
 AZBNP.GOV,State,Non-Federal Agency,Arizona Department of Health Services,Phoenix,AZ,(blank)
-AZBOC.GOV,State,Non-Federal Agency,State of Arizona,Phoenix,AZ,tbunch@azboc.gov
+AZBOC.GOV,State,Non-Federal Agency,State of Arizona,Phoenix,AZ,websecurity@arizona.gov
 AZBOXINGANDMMA.GOV,State,Non-Federal Agency,"State of Arizona, Department of Administration",Phoenix,AZ,ITUnit@azgaming.gov
 AZBROADBAND.GOV,State,Non-Federal Agency,Arizona Department of Administration  ASET Office,PHOENIX,AZ,websecurity@azdoa.gov
 AZBTR.GOV,State,Non-Federal Agency,"State of Arizona, Department of Administration",Phoenix,AZ,(blank)
 AZCANCERCONTROL.GOV,State,Non-Federal Agency,Arizona Department of Health Services,Phoenix,AZ,(blank)
 AZCC.GOV,State,Non-Federal Agency,Arizona Corporation Commission,Phoenix,AZ,(blank)
-AZCENSUS2020.GOV,State,Non-Federal Agency,Arizona Office of Tourism,Phoenix,AZ,mkane@tourism.az.gov
 AZCJC.GOV,State,Non-Federal Agency,Arizona Criminal Justice Commission,Phoenix,AZ,(blank)
 AZCLEANELECTIONS.GOV,State,Non-Federal Agency,Citizens Clean Elections Commission,Phoenix,AZ,(blank)
 AZCOOP.GOV,State,Non-Federal Agency,"State of Arizona, Department of Administration",Phoenix,AZ,websecurity@azdoa.gov
@@ -6214,7 +6239,7 @@ CA.GOV,State,Non-Federal Agency,State of California,Rancho Cordova,CA,(blank)
 CAHWNET.GOV,State,Non-Federal Agency,HHSDC,Sacramento,CA,(blank)
 CALIFORNIA.GOV,State,Non-Federal Agency,State of California,Rancho Cordova,CA,(blank)
 CASAAZ.GOV,State,Non-Federal Agency,Arizona Supreme Court,Phoenix,AZ,(blank)
-CATCHTHECOMETSC.GOV,State,Non-Federal Agency,Central Midlands Regional Transit Authority,Columbia,SC,john.andoh@catchthecomet.org
+CATCHTHECOMETSC.GOV,State,Non-Federal Agency,Central Midlands Regional Transit Authority,Columbia,SC,domaininfo@thecometsc.gov
 CHHDWV.GOV,State,Non-Federal Agency,Cabell-Huntington Health Department,Huntington,WV,(blank)
 CHIAMASS.GOV,State,Non-Federal Agency,Center for Health Information and Analysis,Boston,MA,CHIA-DL-SecurityTeam@MassMail.State.MA.US
 CHILDCARENJ.GOV,State,Non-Federal Agency,Department of Human Services Division of Family Development,Trenton,NJ,(blank)
@@ -6223,6 +6248,7 @@ CHOOSECT.GOV,State,Non-Federal Agency,Department of Economic and Community Devel
 CITYOFRAMSEYMN.GOV,State,Non-Federal Agency,City of Ramsey,Ramsey,MN,RaIT@ci.ramsey.mn.us
 CLAIMITTN.GOV,State,Non-Federal Agency,State of Tennessee,Nashville,TN,Cyber.Security@tn.gov
 CMSPLANFLORIDA.GOV,State,Non-Federal Agency,Florida Department of Health,TALLAHASSEE,FL,(blank)
+CNMILAW.GOV,State,Non-Federal Agency,Commonwealth Law Revision Commission,Saipan,MP,albert.hicking@nmijudiciary.com
 CO.GOV,State,Non-Federal Agency,"Colorado, Governor's Office of Information Technology",Denver,CO,isoc@state.co.us
 COAG.GOV,State,Non-Federal Agency,Colorado Dept. of Law,Denver,CO,bill.waggoner@coag.gov
 COBERTURAMEDICAILLINOIS.GOV,State,Non-Federal Agency,Office of the Governor,Chicago,IL,(blank)
@@ -6636,7 +6662,7 @@ NCDCI.GOV,State,Non-Federal Agency,North Carolina Department of Public Safety,Ra
 NCDCR.GOV,State,Non-Federal Agency,NC Department of Cultural Resources,Raleigh,NC,(blank)
 NCDENR.GOV,State,Non-Federal Agency,NC DEPT OF ENVIRONMENT & NATURAL RESOURCES,RALEIGH,NC,DEQ_ITSecurity@ncdenr.gov
 NCDHHS.GOV,State,Non-Federal Agency,NC Department of Health and Human Services,Raleigh,NC,(blank)
-NCDOI.GOV,State,Non-Federal Agency,North Carolina Department of Insurance,Raleigh,NC,joshua.snyder@ncdoi.gov
+NCDOI.GOV,State,Non-Federal Agency,North Carolina Department of Insurance,Raleigh,NC,ncdoi.iso@ncdoi.gov
 NCDOJ.GOV,State,Non-Federal Agency,North Carolina Department of Justice,Raleigh,NC,(blank)
 NCDOR.GOV,State,Non-Federal Agency,Department of Information Technology,Raleigh,NC,IT_Security@ncdor.gov
 NCDOT.GOV,State,Non-Federal Agency,North Carolina Department of Transportation,Raleigh,NC,security@ncdot.gov
@@ -6754,7 +6780,7 @@ NORTHDAKOTA.GOV,State,Non-Federal Agency,"State of ND, ITD",Bismarck,ND,itsecur@
 NV.GOV,State,Non-Federal Agency,"State of Nevada, Department of Information Technology",Carson City,NV,dmchugh@admin.nv.gov
 NV529.GOV,State,Non-Federal Agency,Nevada State Treasurer's Office,Carson City,NV,security-abuse@nevadatreasurer.gov
 NVAGOMLA.GOV,State,Non-Federal Agency,NV Office of the Attorney General,Carson City,NV,(blank)
-NVCOGCT.GOV,State,Non-Federal Agency,Naugatuck Valley Council of Governments,Waterbury,CT,nvcog@nvcogct.org
+NVCOGCT.GOV,State,Non-Federal Agency,Naugatuck Valley Council of Governments,Waterbury,CT,nvcog@nvcogct.gov
 NVCOURTS.GOV,State,Non-Federal Agency,Supreme Court of Nevada,Carson City,NV,webservices@nvcourts.nv.gov
 NVDPS.GOV,State,Non-Federal Agency,Enterprise IT Services Division,Carson City,NV,iso@dps.state.nv.us
 NVDPSPUB.GOV,State,Non-Federal Agency,Nevada Department of Public Safety,Carson City,NV,dmchugh@admin.nv.gov
@@ -6998,7 +7024,7 @@ TEXASSCHOOLS.GOV,State,Non-Federal Agency,Texas Education Agency,A,TX,(blank)
 TEXASSTATEPARKS.GOV,State,Non-Federal Agency,Texas Parks and Wildlife Department,Austin,TX,michael.golen@tpwd.texas.gov
 TEXASSUPREMECOURTCOMMISSION.GOV,State,Non-Federal Agency,Office of Court Administration,Austin,TX,oca-issecurityteam@txcourts.gov
 TEXASSURPLUS.GOV,State,Non-Federal Agency,Texas Facilities Commission,Austin,TX,martha.smith@tfc.state.tx.us
-THECOMETSC.GOV,State,Non-Federal Agency,Central Midlands Regional Transit Authority,Columbia,SC,john.andoh@catchthecomet.org
+THECOMETSC.GOV,State,Non-Federal Agency,Central Midlands Regional Transit Authority,Columbia,SC,domaininfo@thecometsc.gov
 THEFTAZ.GOV,State,Non-Federal Agency,Attorney General General Office,Phoenix,AZ,terry.dupree@azag.gov
 THESTATEOFSOUTHCAROLINA.GOV,State,Non-Federal Agency,"State of South Carolina—The South Carolina Department of Administration, Chief Information Officer",Columbia,SC,randy.rambo@admin.sc.gov
 TN.GOV,State,Non-Federal Agency,State of Tennessee,Nashville,TN,Cyber.Security@tn.gov


### PR DESCRIPTION
27 new domains activated this week, including the first .gov domain for the Commonwealth of the Northern Mariana Islands (`cnmilaw.gov`). No current-federal updates.