### PR TITLE
Add a handful of domains for EEOC

### DIFF
--- a/dotgov-websites/other-websites.csv
+++ b/dotgov-websites/other-websites.csv
@@ -17036,3 +17036,17 @@ eexdr.employeeexpress.gov
 test.admin.employeeexpress.gov
 cldcentral.usalearning.gov
 de.usalearning.gov
+alertus.eeoc.gov
+arc.eeoc.gov
+arctest.eeoc.gov
+arctrain.eeoc.gov
+arcuat.eeoc.gov
+dev.eeoc.gov
+egovtest.eeoc.gov
+egovuat.eeoc.gov
+imsuat.eeoc.gov
+nxgtest.eeoc.gov
+relativity.eeoc.gov
+shinyr.eeoc.gov
+uat-www.eeoc.gov
+eeocdata.org


### PR DESCRIPTION
EEOC requested we add a handful of domains to their BOD 18-01 reports that aren't presently showing. Non-.gov also added to the non-.govs list here: https://github.com/cisagov/scan-target-data/pull/80.


