### PR TITLE
Added 4 OCSP Domains for EOP

### DIFF
--- a/dotgov-websites/ocsp-crl.csv
+++ b/dotgov-websites/ocsp-crl.csv
@@ -43,3 +43,7 @@ smime2.nist.gov
 pki.fhfa.gov
 dc081.fhfa.gov
 va081.fhfa.gov
+ssee-ocss001.ocsp.dmz.pitc.gov
+ssee-ocss002.ocsp.dmz.pitc.gov
+399e-ocss002.ocsp.dmz.pitc.gov
+399e-ocss001.ocsp.dmz.pitc.gov


### PR DESCRIPTION
EOP has requested that we add the four domain names to this list so that they no longer show on their reports. Confirmed with EOP that these domains are used only for OSCP/CRL purposes.


