### PR TITLE
Add 3 DOT Domains for HTTPS Exception

### DIFF
--- a/dotgov-websites/ocsp-crl.csv
+++ b/dotgov-websites/ocsp-crl.csv
@@ -49,3 +49,6 @@ ssee-ocss002.ocsp.dmz.pitc.gov
 399e-ocss001.ocsp.dmz.pitc.gov
 test1carepository.faa.gov
 test1certvalidation.faa.gov
+keys1.dot.gov
+keys2.dot.gov
+crl.oig.dot.gov


### PR DESCRIPTION
DOT has requested these domain be marked as an exception for their HTTPS compliance report due to being CRL centric only.


