### PR TITLE
Add 1 USDA Subdomain

### DIFF
--- a/dotgov-websites/other-websites.csv
+++ b/dotgov-websites/other-websites.csv
@@ -17191,3 +17191,4 @@ trespasstoolkit.fra.dot.gov
 tds-ext.fra.dot.gov
 rcs-externalshare.fra.dot.gov
 aasportal.fra.dot.gov
+lessons.fs2c.usda.gov


### PR DESCRIPTION
USDA has requested that we add lessons.fs2c.usda.gov so that it shows up in their Trustymail and HTTPS reports. I verified it is not currently being picked up in the sources gathered by double checking for its presence in their report.


