### PR TITLE
Update other-websites.csv

### DIFF
--- a/dotgov-websites/other-websites.csv
+++ b/dotgov-websites/other-websites.csv
@@ -17191,3 +17191,4 @@ rcs-externalshare.fra.dot.gov
 aasportal.fra.dot.gov
 lessons.fs2c.usda.gov
 gcn.nasa.gov
+supervisionportal.cfpb.gov


### PR DESCRIPTION
CFPB has requested that we add "supervisionportal.cfpb.gov" so that it shows up in their Trustymail and HTTPS reports. I verified it is not currently being picked up in the sources gathered by double checking for its presence in their report.


