### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,4 @@ Find a **security or privacy issue** on one of these domains? Review our [securi
 ## Unofficial uses
 
 * [Accept the Risk and Continue: Measuring the Long Tail of Government https Adoption](https://sudheesh.info/papers/imc20.pdf). Sudheesh Singanamalla, Esther Han Beol Jang, Richard Anderson, Tadayoshi Kohno, and Kurtis Heimerl. 2020. In Proceedings of the ACM Internet Measurement Conference (IMC '20). Association for Computing Machinery, New York, NY, USA, 577–597. [DOI](https://doi.org/10.1145/3419394.3423645)
-* Lauren Ancona made a [geocoded map of .gov domains](http://laurenancona.com/maps/gov_domains.html):
 
-[![gov_domains](https://cloud.githubusercontent.com/assets/2152151/5627069/ba4185e2-9561-11e4-873a-54d9f480ec3e.jpg)](http://laurenancona.com/maps/gov_domains.html)


### PR DESCRIPTION
Even though the example usage is "Unofficial" the map is inaccurate. Given mapping domain name to location is the sole purpose of this example usage of the data, it should not be included.


- remove inaccurate map
- There are numerous inaccurate correlations between locations and domain names.  