### PR TITLE
Update current-federal/full daily once again

### DIFF
--- a/.github/workflows/flat.yml
+++ b/.github/workflows/flat.yml
@@ -19,10 +19,10 @@ jobs:
       - name: Fetch data
         uses: githubocto/flat@v3
         with:
-          http_url: https://domains.dotgov.gov/dotgov-web/publicreports/current-federal
+          http_url: https://manage.get.gov/api/v1/get-report/current-federal
           downloaded_filename: current-federal.csv
       - name: Fetch data
         uses: githubocto/flat@v3
         with:
-          http_url: https://domains.dotgov.gov/dotgov-web/publicreports/current-full
+          http_url: https://manage.get.gov/api/v1/get-report/current-full
           downloaded_filename: current-full.csv


### PR DESCRIPTION
Updates our git-scraping file so Actions can pull daily updates from the .gov registry. THE DOMAINS MUST FLOW

With #114, this closes #106.