### PR TITLE
Update other-websites.csv

### DIFF
--- a/dotgov-websites/other-websites.csv
+++ b/dotgov-websites/other-websites.csv
@@ -17192,3 +17192,9 @@ aasportal.fra.dot.gov
 lessons.fs2c.usda.gov
 gcn.nasa.gov
 supervisionportal.cfpb.gov
+capos.marad.dot.gov
+sparks-stage.nhtsa.dot.gov
+sparks-dev.nhtsa.dot.gov
+sparks-test.nhtsa.dot.gov
+sparks.nhtsa.dot.gov
+sftp1.phmsa.dot.gov


### PR DESCRIPTION
DOT has requested that we add the following sites so that they no longer show up in their Trustymail and HTTPS reports. I verified they are not currently being picked up in the sources gathered by double checking for their presence in their report.

capos.marad.dot.gov
sparks-stage.nhtsa.dot.gov
sparks-dev.nhtsa.dot.gov
sparks-test.nhtsa.dot.gov
sparks.nhtsa.dot.gov
sftp1.phmsa.dot.gov


