### PR TITLE
Update mutual-tls-fceb.csv

### DIFF
--- a/dotgov-websites/mutual-tls-fceb.csv
+++ b/dotgov-websites/mutual-tls-fceb.csv
@@ -6,7 +6,6 @@ access.nrc.gov
 access10.nrc.gov
 access2.cpsc.gov
 accesstest-piv.cdc.gov
-accpiv.treasury.gov
 activesync.fincen.gov
 activesync.lab365.myfdic.gov
 adfs.nrel.gov
@@ -76,7 +75,6 @@ doc.pkilogin1.asap.gov
 doc.pkilogin1.fiscal.treasury.gov
 doc.pkilogin1.fms.treas.gov
 doc.pkilogin1.its.gov
-doctest.pkilogin1.fiscal.treasury.gov
 doefoci-cert.anl.gov
 domakroc.treasury.gov
 domas.treasury.gov
@@ -106,7 +104,6 @@ eroc.pkilogin1.asap.gov
 eroc.pkilogin1.fiscal.treasury.gov
 eroc.pkilogin1.fms.treas.gov
 eroc.pkilogin1.its.gov
-eroctest.pkilogin1.fiscal.treasury.gov
 etscpsvc-dfw.fdic.gov
 etscpsvc-old.fdic.gov
 etscpsvc-vas.fdic.gov
@@ -132,8 +129,6 @@ fplspiv.acf.hhs.gov
 fsacitrixweb-piv.ed.gov
 fsbyodtunnel.ent.usda.gov
 fstunnel.ent.usda.gov
-ft-future2.ws.otcnet.fms.treas.gov
-fttest.pkilogin1.fiscal.treasury.gov
 fx01tcps.pnnl.gov
 gateway2.nrc.gov
 gb-mic-sasentry.fcc.gov
@@ -228,7 +223,6 @@ piv.citrix.mms.gov
 piv.ojp.usdoj.gov
 piv.services.treasury.gov
 piv.state.gov
-piv.treasury.gov
 piv.vdid.census.gov
 pivash.ojp.usdoj.gov
 pivdal.ojp.usdoj.gov
@@ -237,8 +231,6 @@ pivstaging.ojp.usdoj.gov
 pivstagingash.ojp.usdoj.gov
 pivstagingdal.ojp.usdoj.gov
 pki.eauth.va.gov
-pkilogin-pp.fms.treas.gov
-pkilogin1.portal.donotpay.treas.gov
 pliny.lanl.gov
 pnnlinfowsdev.pnl.gov
 poc4.o365.fema.dhs.gov
@@ -249,17 +241,9 @@ proxied-bep-f5.lanl.gov
 proxied-nissforum-f5.lanl.gov
 proxied-nsgregister-f5.lanl.gov
 qa.pkilogin1.fms.treas.gov
-qa.svctransfer.fms.treas.gov
 qa.tcs.pay.gov
-qaa.ws.otcnet.fms.treas.gov
 qacur.tcs.pay.gov
 qadev.tcs.pay.gov
-qae-future.ws.otcnet.fms.treas.gov
-qae.ws.otcnet.fms.treas.gov
-qaf.svctransfer.fiscal.treasury.gov
-qai-future.ws.otcnet.fms.treas.gov
-qai.ws.otcnet.fms.treas.gov
-qatest.pkilogin1.fiscal.treasury.gov
 quickconnect-dc2.dhs.gov
 quickconnect.dhs.gov
 r-ioe.defimnet.fws.gov
@@ -341,8 +325,6 @@ workspace.usda.gov
 ws.defimnet.fws.gov
 ws.dev.grants.gov
 ws.igt.fiscal.treasury.gov
-ws.otcnet.fms.treas.gov
-ws.sam.fms.treas.gov
 x509-acc.treasury.gov
 x509-dev.treasury.gov
 x509.treasury.gov


### PR DESCRIPTION
Removes decommissioned Treasury services from the mTLS list.


