### PR TITLE
Add git pull before gov.txt workflow pushes to main

### DIFF
--- a/.github/workflows/update-gov-zone-file.yml
+++ b/.github/workflows/update-gov-zone-file.yml
@@ -27,4 +27,5 @@ jobs:
           git add gov.txt
           timestamp=$(date -u)
           git commit -m "CZDS Update ${timestamp}" || exit 0
+          git pull
           git push


### PR DESCRIPTION
Adds a `git pull` before pushing to main on daily gov.txt update workflow. This resolves the `error: failed to push some refs` error when a user re-runs the workflow after a previous job fails to complete (more information on [this blog post](https://jonathansoma.com/everything/git/github-actions-refs-error/)). The PR runs `git pull` to combine data from the previous incomplete job with the currently run job to prevent confusion on GitHub's end.