### PR TITLE
Added 6 OCSP Domains for DOT

### DIFF
--- a/dotgov-websites/ocsp-crl.csv
+++ b/dotgov-websites/ocsp-crl.csv
@@ -48,6 +48,12 @@ ssee-ocss002.ocsp.dmz.pitc.gov
 399e-ocss002.ocsp.dmz.pitc.gov
 399e-ocss001.ocsp.dmz.pitc.gov
 test1carepository.faa.gov
+niws_443_vs.nas.faa.gov
+www.nes.notams.faa.gov
+aidap_443_vs.nas.faa.gov
+www.aidap.naimes.faa.gov
+nes_443_vs.nas.faa.gov
+nes.notams.faa.gov
 test1certvalidation.faa.gov
 keys1.dot.gov
 keys2.dot.gov


### PR DESCRIPTION
DOT has requested that we add the six domain names to this list so that they no longer show on their reports. Confirmed with DOT that these domains are used only for OSCP/CRL purposes. (SNOW VMC0024227)


