### PR TITLE
Issue #135: Fix failed action in current-full/federal update

### DIFF
--- a/.github/workflows/flat.yml
+++ b/.github/workflows/flat.yml
@@ -16,6 +16,9 @@ jobs:
           deno-version: v1.x
       - name: Check out repo
         uses: actions/checkout@v2
+      - name: Pull from main
+        run: |-
+          git pull
       - name: Fetch data
         uses: githubocto/flat@v3
         with:


### PR DESCRIPTION
Resolves #135
Adds `git pull` before running the fetch actions to prevent a race condition between the two active GH jobs. 