### PR TITLE
Make the zone files updates less about Cloudflare

### DIFF
--- a/.github/workflows/update-gov-zone-file.yml
+++ b/.github/workflows/update-gov-zone-file.yml
@@ -1,5 +1,5 @@
-name: Update gov.txt from Cloudflare zone file
-run-name: Update gov.txt from Cloudflare zone file
+name: Update gov.txt from zone file
+run-name: Update gov.txt from zone file
 
 on:
   workflow_dispatch: {}
@@ -17,7 +17,7 @@ jobs:
           git config user.name "botgov"
           git config user.email "help@get.gov"
           git config pull.rebase false
-      - name: Pull latest Cloudflare zone file into gov.txt
+      - name: Pull latest zone file into gov.txt
         env:
           CLOUDFLARE_ZONE: '${{ secrets.CLOUDFLARE_ZONE }}'
           CLOUDFLARE_TOKEN: '${{ secrets.CLOUDFLARE_TOKEN }}'
@@ -30,6 +30,6 @@ jobs:
         run: |-
           git add gov.txt
           timestamp=$(date -u)
-          git commit -m "Pull Cloudflare zone data ${timestamp}" || exit 0
+          git commit -m "Update zone file ${timestamp}" || exit 0
           git pull
           git push


### PR DESCRIPTION
This small change de-Cloudflare-ifies the metadata in the zone file update Action/commit message. (It's our zone, they just host it. 😅)