### PR TITLE
Correction for DOT (FAA)

### DIFF
--- a/dotgov-websites/ocsp-crl.csv
+++ b/dotgov-websites/ocsp-crl.csv
@@ -49,7 +49,6 @@ ssee-ocss002.ocsp.dmz.pitc.gov
 399e-ocss001.ocsp.dmz.pitc.gov
 test1carepository.faa.gov
 niws_443_vs.nas.faa.gov
-www.nes.notams.faa.gov
 aidap_443_vs.nas.faa.gov
 www.aidap.naimes.faa.gov
 nes_443_vs.nas.faa.gov
@@ -60,3 +59,4 @@ keys2.dot.gov
 crl.oig.dot.gov
 crl.rk.convergeoperations.com
 pki.epa.gov
+www.niws.notams.faa.gov

--- a/dotgov-websites/ocsp-crl.csv
+++ b/dotgov-websites/ocsp-crl.csv
@@ -49,6 +49,7 @@ ssee-ocss002.ocsp.dmz.pitc.gov
 399e-ocss001.ocsp.dmz.pitc.gov
 test1carepository.faa.gov
 niws_443_vs.nas.faa.gov
+www.niws.notams.faa.gov
 aidap_443_vs.nas.faa.gov
 www.aidap.naimes.faa.gov
 nes_443_vs.nas.faa.gov
@@ -59,4 +60,3 @@ keys2.dot.gov
 crl.oig.dot.gov
 crl.rk.convergeoperations.com
 pki.epa.gov
-www.niws.notams.faa.gov


### PR DESCRIPTION
There was a typo on their submission form, for VMC0024227. They are requesting to correct niws_443_vs.nas.faa.gov 152.123.8.137 from www.nes.notams.faa.gov (typo)
to www.niws.notams.faa.gov (correct)


