### PR TITLE
Add 1 Treasury Domain

### DIFF
--- a/dotgov-websites/other-websites.csv
+++ b/dotgov-websites/other-websites.csv
@@ -5561,6 +5561,7 @@ fohwebitiostage.foh.psc.gov
 foia.opm.gov
 foia.state.fan.gov
 foia.state.gov
+foia.treasury.gov
 foia1.ftc.gov
 foia2.ftc.gov
 foiaportal.nih.gov


### PR DESCRIPTION
Treasury has requested that we add 1 subdomain (foia.treasury.gov) to their Trustymail and HTTPS reports. I verified it is not currently being picked up in the sources gathered by double checking for its presence in our database and their reports.


