### PR TITLE
Add 3 TREAS domains

### DIFF
--- a/dotgov-websites/other-websites.csv
+++ b/dotgov-websites/other-websites.csv
@@ -5380,6 +5380,7 @@ fermi.cam.nist.gov
 ferret.bls.census.gov
 ferret.pmel.noaa.gov
 fers.tva.gov
+ffb.treasury.gov
 ffc-daigoro.sb.biodatacatalyst.nhlbi.nih.gov
 ffc-durin.sb.biodatacatalyst.nhlbi.nih.gov
 ffc-fs-fe.sb.biodatacatalyst.nhlbi.nih.gov
@@ -13679,6 +13680,7 @@ sbe.naepims.org
 sbe2018-stage.naepims.org
 sbecentral-test.naepims.org
 sbecentral.naepims.org
+sbecs.treas.gov
 sbemonitor-test.naepims.org
 sbir.ha2.cancer.gov
 sbms.hhs.gov
@@ -15424,6 +15426,7 @@ teenpregnancy.acf.hhs.gov
 tegucigalpa.osac.gov
 tegucigalpa.usembassy.gov
 tehran.usembassy.gov
+tei.treasury.gov
 tek300.nws.noaa.gov
 tektite.nist.gov
 tel2018uploader.naepims.org
@@ -18843,6 +18846,3 @@ zw.edit.usembassy.gov
 zw.pre.usembassy.gov
 zw.usembassy.gov
 zygo.nist.gov
-ffb.treasury.gov
-tei.treasury.gov
-sbecs.treas.gov

--- a/dotgov-websites/other-websites.csv
+++ b/dotgov-websites/other-websites.csv
@@ -18843,3 +18843,6 @@ zw.edit.usembassy.gov
 zw.pre.usembassy.gov
 zw.usembassy.gov
 zygo.nist.gov
+ffb.treasury.gov
+tei.treasury.gov
+sbecs.treas.gov


### PR DESCRIPTION
TREAS has requested that we add ffb.treasury.gov, tei.treasury.gov and sbecs.treas.gov so that it shows up in their Trustymail and HTTPS reports. I verified it is not currently being picked up in the sources gathered by double checking for its presence in their report


