### PR TITLE
Add 2 DOI Subdomains

### DIFF
--- a/dotgov-websites/other-websites.csv
+++ b/dotgov-websites/other-websites.csv
@@ -3498,11 +3498,13 @@ database.atdd.noaa.gov
 datadictionary.llnl.gov
 dataexplorer.northwestscience.fisheries.noaa.gov
 dataferrett.census.gov
+datagovernance.doi.gov
 dataheroes.llnl.gov
 datahub.cms.gov
 datahub.pnnl.gov
 dataiku.staging.aetc.appdat.jsc.nasa.gov
 dataintheclassroom.noaa.gov
+datainventory.doi.gov
 datainventory.ed.gov
 datamapper.geo.census.gov
 datamapper.test.geo.census.gov


### PR DESCRIPTION
DOI has requested that we add 2 subdomains (datainventory.doi.gov & datagovernance.doi.gov) to their Trustymail and HTTPS reports. I verified they are not currently being picked up in the sources gathered by double checking for their presence in our database and their reports.


