### PR TITLE
Added 6 OSCP domains for DOT

### DIFF
--- a/dotgov-websites/ocsp-crl.csv
+++ b/dotgov-websites/ocsp-crl.csv
@@ -1,3 +1,9 @@
+dotdr1vdi015vg.dot.gov 
+dotdr1vdi016vg.dot.gov
+dotdr1vdi017vg.dot.gov 
+dothqevdi015vg.dot.gov 
+dothqevdi016vg.dot.gov 
+dothqevdi017vg.dot.gov
 ocsp-1.llnl.gov
 ocsp-2.llnl.gov
 ocsp.llnl.gov


### PR DESCRIPTION
DOT has requested that we add the six domain names to this list so that they no longer show on their reports. Confirmed with DOT that these domains are used only for OSCP/CRL purposes.


