### PR TITLE
ci: SHA-pin third-party Actions across both workflows

### DIFF
--- a/.github/workflows/flat.yml
+++ b/.github/workflows/flat.yml
@@ -13,21 +13,21 @@ jobs:
       contents: write
     steps:
       - name: Setup deno
-        uses: denoland/setup-deno@main
+        uses: denoland/setup-deno@ff4860f9d7236f320afa0f82b7e6457384805d05 # pinned from main
         with:
           deno-version: v1.x
       - name: Check out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Pull from main
         run: |-
           git pull
       - name: Fetch data
-        uses: githubocto/flat@v3
+        uses: githubocto/flat@cea5ee43fce40ef71501bf5724a00d45db11641d # v3.4.0
         with:
           http_url: https://manage.get.gov/api/v1/get-report/current-federal
           downloaded_filename: current-federal.csv
       - name: Fetch data
-        uses: githubocto/flat@v3
+        uses: githubocto/flat@cea5ee43fce40ef71501bf5724a00d45db11641d # v3.4.0
         with:
           http_url: https://manage.get.gov/api/v1/get-report/current-full
           downloaded_filename: current-full.csv

--- a/.github/workflows/update-gov-zone-file.yml
+++ b/.github/workflows/update-gov-zone-file.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Initialize git config and sets pull to merge
         run: |-
           git config user.name "botgov"


### PR DESCRIPTION
Replaces 5 tag references in `.github/workflows/` with commit SHAs, with the resolved tag/branch as a trailing comment.

## Changes (2 files, 5 references)

- `actions/checkout@v2` and `@v4` to resolved SHAs (`v2.7.0`, `v4.3.1`)
- `denoland/setup-deno@main` to SHA at current head of main
- `githubocto/flat@v3` to SHA at v3.4.0 (2 occurrences in flat.yml)

The `denoland/setup-deno@main` change is the most material: as a branch ref it can shift any time `denoland` updates main, which makes the dotgov-data build non-deterministic. SHA-pinning to the current head locks in the contract.

## Why

Same supply-chain hardening posture as the wider community response after CVE-2025-30066 (the `tj-actions/changed-files` compromise in March). A commit SHA is immutable; tags and branches are not.

YAML validated locally with `yaml.safe_load`.