### PR TITLE
Add state laws

### DIFF
--- a/state-laws.md
+++ b/state-laws.md
@@ -1,0 +1,60 @@
+This is a non-official compendium of known state laws and bills in the United States relating to the .gov top-level domain. It should not be treated as authoritative.
+
+| State/territory | Type | Citation | Year enacted | Effective date | Legislative history | Summary | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Alabama (AL) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Alaska (AK) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| American Samoa (AS) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Arizona (AZ) | ~ | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Arkansas (AR) | Law | [Ark. Code Ann. § 14-1-115 (2026)](https://advance.lexis.com/documentpage/?pdmfid=1000516&crid=bd85789f-6979-4b47-a7c6-07c5cd48f798&nodeid=AAOAABAACAACAAQ&nodepath=%2FROOT%2FAAO%2FAAOAAB%2FAAOAABAAC%2FAAOAABAACAAC%2FAAOAABAACAACAAQ&level=5&haschildren=&populated=false&title=14-1-115.+Municipal+government+%E2%80%94+Use+of+authorized+domain+extension.+%5BEffective+June+1%2C+2026%2C+for+cities+and+towns+with+population+of+10%2C000+inhabitants+or+more%3B+effective+January+1%2C+2027%2C+for+cities+and+towns+with+population+of+fewer+than+10%2C000+inhabitants.%5D&config=00JAA2ZjZiM2VhNS0wNTVlLTQ3NzUtYjQzYy0yYWZmODJiODRmMDYKAFBvZENhdGFsb2fXiYCnsel0plIgqpYkw9PK&pddocfullpath=%2Fshared%2Fdocument%2Fstatutes-legislation%2Furn%3AcontentItem%3A6G28-65J0-R03K-K42Y-00008-00&ecomp=6gf5kkk&prid=33227a27-da4d-4096-99fa-0c127c1b9548) (cities/towns); [Ark. Code Ann. § 25-1-132 (2026)](https://advance.lexis.com/documentpage/?pdmfid=1000516&crid=5ef2b627-094b-474d-b365-ba2a39bd8cf1&nodeid=AAZAACAACABJ&nodepath=%2FROOT%2FAAZ%2FAAZAAC%2FAAZAACAAC%2FAAZAACAACABJ&level=4&haschildren=&populated=false&title=25-1-132.+State+agencies%2C+boards%2C+or+commissions+%E2%80%94+Use+of+authorized+domain+extension+%E2%80%94+Definition.+%5BEffective+June+1%2C+2026.%5D&config=00JAA2ZjZiM2VhNS0wNTVlLTQ3NzUtYjQzYy0yYWZmODJiODRmMDYKAFBvZENhdGFsb2fXiYCnsel0plIgqpYkw9PK&pddocfullpath=%2Fshared%2Fdocument%2Fstatutes-legislation%2Furn%3AcontentItem%3A6GP7-7VP0-R03J-R4WT-00008-00&ecomp=6gf5kkk&prid=80caac8d-90f1-4ae2-86a7-a53c4a656d29) (state agencies, etc.) | 2025 | June 1, 2026 for state agencies + cities/towns with >10k population; January 1, 2027 for cities/towns with less | [HB1951 - To set forth authorized domain extensions for higher education and government websites](https://arkleg.state.ar.us/Bills/Detail?id=HB1951&ddBienniumSession=2025%2F2025R) | Municipal governments must use ".gov" domain extensions for their primary websites and email addresses, and state agencies must use either ".gov" or ".mil" domains. | ~ |
+| California (CA) | Law | [Cal. Gov't Code § 50034](https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=GOV&sectionNum=50034) | 2023 | January 1, 2029 | [AB-1637 Local government: internet websites and email addresses](https://leginfo.legislature.ca.gov/faces/billHistoryClient.xhtml?bill_id=202320240AB1637) | Requires local agencies to use .gov or a subdomain of ca.gov for websites and email addresses. Noncompliant agencies must redirect to compliant domains. | A bill in the 2025-2026 session, [AB-810](https://leginfo.legislature.ca.gov/faces/billNavClient.xhtml?bill_id=202520260AB810), would require special districts, joint powers authorities, or other political subdivisions to use .gov/.ca.gov. It would expressly not apply to K-12 school districts, and would allow eligible educative institutions to use .edu. |
+| Colorado (CO) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Connecticut (CT) | Law | [Conn. Gen. Stat. § 7-101b (2026)](https://www.cga.ct.gov/2026/sup/chap_097.htm) | 2025 | July 1, 2027 | [Substitute for S.B. No. 3: An act concerning consumer protection and safety](https://www.cga.ct.gov/asp/cgabillstatus/cgabillstatus.asp?selBillType=Bill&which_year=2025&bill_num=SB+3) | By July 1, 2027, municipalities must register a ".gov" domain and redirect any existing websites to it or discontinue them. | A [bill](https://www.cga.ct.gov/asp/cgabillstatus/cgabillstatus.asp?selBillType=Bill&which_year=2024&bill_num=227) from the 2024 legislative session with similar language died in chamber. |
+| District of Columbia (DC) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Delaware (DE) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Florida (FL) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Georgia (GA) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Guam (GU) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Hawaii (HI) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Idaho (ID) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Illinois (IL) | ~ | [10 Ill. Comp. Stat. 5/1-18](https://www.ilga.gov/legislation/ILCS/details?MajorTopic=GOVERNMENT&Chapter=ELECTIONS&ActName=Election%20Code.&ActID=170&ChapterID=3&SeqStart=&&ChapAct=FullText) | 2021 | 2022 | [Bill Status of SB0825](https://ilga.gov/Legislation/BillStatus?DocNum=825&GAID=16&DocTypeID=SB&LegId=133452&SessionID=110) | Each election authority maintaining a website shall begin utilizing a ".gov" website address and a ".gov" electronic mail address for each employee within one year of the effective date of the act. |
+| Indiana (IN) | ~ | [Ind. Code § 4-13.1-4-8 (2025)](https://iga.in.gov/laws/2025/ic/titles/4#4-13.1-4-8) | 2024 | July 1, 2027 | [SB0150](https://legiscan.com/IN/bill/SB0150/2024) ([iga.in.gov](https://iga.in.gov/legislative/2024/bills/senate/150/actions)) | After July 1, 2027, public entities connecting to state infrastructure must have an "in.gov" or ".gov" domain. | ~ |
+| Iowa (IA) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Kansas (KS) | Law | [Kan. Stat. Ann. § 75-7245 (2024)](https://www.kslegislature.gov/b2023_24/bills/sb291/) (branch/state agencies) and [Kan. Stat. Ann. 2025 Supp. § 25-2316c](https://ksrevisor.gov/statutes/chapters/ch25/025_023_0016c.html) (voter registration sites; *link doesn't include enrolled text yet, July 2026*) | 2024; 2026 | February 1, 2025 | [SB 291](https://www.kslegislature.gov/b2023_24/bills/sb291/) (2023-2024 legislative session; branch/state agencies) and [HB 2437 Establishing the save Kansas](https://www.kslegislature.gov/b2025_26/bills/HB2437/) (2025–2026 legislative session; voter registration sites) | **75-7245**: Every website that is maintained by a branch of government or state agency shall be moved to a .gov domain. **25-2316c**: Mandates that any website used to register to vote must either have a .gov domain or be specifically approved by the Secretary of State. | ~ |
+| Kentucky (KY) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Louisiana (LA) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Maine (ME) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Maryland (MD) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Massachusetts (MA) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Michigan (MI) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Minnesota (MN) | Law | [Minn. Stat. § 471.3422 (2025)](https://www.revisor.mn.gov/statutes/cite/471.3422) | 2024 | June 1, 2026 | [HF 4772 Elections policy and finance bill](https://www.revisor.mn.gov/bills/93/2024/0/HF/4772/) | Counties and municipalities administering absentee voting must use .gov domains by June 1, 2026. Full transition by June 1, 2028. | ~ |
+| Mississippi (MS) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Missouri (MO) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Montana (MT) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Nebraska (NE) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Nevada (NV) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| New Hampshire (NH) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| New Jersey (NJ) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| New Mexico (NM) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| New York (NY) | Law | [N.Y. Gen. Mun. Law § 300 (2026)](https://www.nysenate.gov/legislation/laws/GMU/300) | 2025 | February 28, 2026 | [Senate Bill S783](https://www.nysenate.gov/legislation/bills/2025/S783) (2025-2026 legislative session) | The websites of "municipal corporations" with a population greater than 1,500 must use a .gov domain (hosting on another municipality's domain is also allowed). SB S783 amended law that was [passed](https://www.nysenate.gov/legislation/bills/2023/S3353/amendment/A) in 2023-2024 legislative session, which originally went into effect [on](https://www.timeanddate.com/date/dateadded.html?m1=12&d1=21&y1=2024&type=add&ay=&am=&aw=&ad=180&rec=) June 19, 2025. | A [bill](https://www.nysenate.gov/legislation/bills/2021/S4865) from the 2021-2022 session targeted Boards of Elections using .gov died in committee. |
+| North Carolina (NC) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| North Dakota (ND) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Northern Mariana Islands | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Ohio (OH) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Oklahoma (OK) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Oregon (OR) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Pennsylvania (PA) | Bill | ~ | ~ | ~ | [HB0474](https://www.palegis.us/legislation/bills/2025/hb474) and [HB1217](https://www.palegis.us/legislation/bills/2025/hb1217) (2025-2026 regular session) | HB 474 (D-sponsored) and HB 1217 (R-sponsored) are two bills that would require county boards of elections to maintain a website with a .gov domain. |
+| Puerto Rico (PR) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Rhode Island (RI) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| South Carolina (SC) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| South Dakota (SD) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Tennessee (TN) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Texas (TX) | Bill | ~ | ~ | ~ | [HB 657](https://capitol.texas.gov/BillLookup/History.aspx?LegSess=89R&Bill=HB657) (89th regular session, 2025-2026) | Requires counties to use .gov or *.texas.gov for any website used to post election information. | ~ |
+| Utah (UT) | Law | [Utah Code § 63A-16-110 (2025)](https://le.utah.gov/xcode/Title63A/Chapter16/63A-16-S110.html?v=C63A-16-S110_2025032720250507) | 2023 |July 1, 2025 | [S.B. 127 Cybersecurity Amendments](https://le.utah.gov/~2023/bills/static/SB0127.html) (2023 general session) | Governmental entities must use authorized top-level domains (.gov, .edu, or .mil) for websites and email addresses. | ~ |
+| Vermont (VT) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Virginia (VA) | Bill | ~ | ~ | ~ | [HB707 State government; transaction of public business, prohibited website domains](https://lis.virginia.gov/bill-details/20261/HB707) (2026 regular session) | "No public body shall maintain an official website for public use with a domain other than a .gov, .edu, or .museum domain." | The bill passed in the House but died in Senate committee. |
+| Washington (WA) | Law | [Wash. Rev. Code § 29A.12.210 (2025)](https://apps.leg.wa.gov/rcw/default.aspx?cite=29A.12.210) | 2025 | July 1, 2027 | [SB 5014 - 2025-26](https://app.leg.wa.gov/billsummary?BillNumber=5014&Initiative=false&Year=2025) | County auditors must implement cybersecurity measures including adoption of .gov domains for election and voting systems by July 1, 2027. | ~ |
+| West Virginia (WV) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Wisconsin (WI) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| Wyoming (WY) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |
+| U.S. Virgin Islands (VI) | ~ | ~ | ~ | ~ | ~ | ~ | ~ |


### PR DESCRIPTION
This PR adds the state laws and bills that we know about to dotgov-data.

This work began in a [wiki over in the get.gov repo](https://github.com/cisagov/get.gov/wiki/Known-state-laws-about-.gov), but moving it here and out of a wiki feels right.