### PR TITLE
Update Actions dependancies and improve error handling

### DIFF
--- a/.github/workflows/flat.yml
+++ b/.github/workflows/flat.yml
@@ -12,22 +12,19 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Setup deno
-        uses: denoland/setup-deno@main
-        with:
-          deno-version: v1.x
       - name: Check out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Pull from main
         run: |-
           git pull
-      - name: Fetch data
-        uses: githubocto/flat@v3
-        with:
-          http_url: https://manage.get.gov/api/v1/get-report/current-federal
-          downloaded_filename: current-federal.csv
-      - name: Fetch data
-        uses: githubocto/flat@v3
-        with:
-          http_url: https://manage.get.gov/api/v1/get-report/current-full
-          downloaded_filename: current-full.csv
+      - name: Fetch current-federal
+        run: curl -fsSL -o current-federal.csv "https://manage.get.gov/api/v1/get-report/current-federal"
+      - name: Fetch current-full
+        run: curl -fsSL -o current-full.csv "https://manage.get.gov/api/v1/get-report/current-full"
+      - name: Commit updated data
+        run: |
+          git config user.name "botgov"
+          git config user.email "help@get.gov"
+          git add current-federal.csv current-full.csv
+          git commit -m "Latest data ($(date -u +%FT%TZ))" || exit 0
+          git push

--- a/.github/workflows/update-gov-zone-file.yml
+++ b/.github/workflows/update-gov-zone-file.yml
@@ -1,11 +1,9 @@
 name: Update gov.txt from zone file
 run-name: Update gov.txt from zone file
-
 on:
   workflow_dispatch: {}
   schedule:
     - cron: "5 7 * * *"
-
 jobs:
   update_zone_file:
     runs-on: ubuntu-latest
@@ -13,7 +11,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Initialize git config and sets pull to merge
         run: |-
           git config user.name "botgov"
@@ -24,12 +22,25 @@ jobs:
           CLOUDFLARE_ZONE: '${{ secrets.CLOUDFLARE_ZONE }}'
           CLOUDFLARE_TOKEN: '${{ secrets.CLOUDFLARE_TOKEN }}'
         run: |
+          set -e
           chmod +x ./scripts/download_zone_file.sh
-          ./scripts/download_zone_file.sh '${{ env.CLOUDFLARE_ZONE }}' '${{ env.CLOUDFLARE_TOKEN }}' > gov.txt
+          # The script reads CLOUDFLARE_ZONE / CLOUDFLARE_TOKEN from the env
+          # block above, so no secrets are passed on the command line.
+          # Write to a temp file first; only replace gov.txt if the script
+          # succeeds, so a failed fetch never clobbers the good file.
+          ./scripts/download_zone_file.sh > gov.txt.new
+          mv gov.txt.new gov.txt
         shell: sh
       # Push daily zone file to branch only if a diff is found
       - name: If pulled data has changes, commit and push changes to zone file.
         run: |-
+          # Defense in depth: refuse to commit an implausibly small gov.txt
+          # even if a bad file somehow slipped past the download script.
+          lines=$(wc -l < gov.txt)
+          if [ "$lines" -lt 1000 ]; then
+            echo "gov.txt only $lines lines; refusing to commit" >&2
+            exit 1
+          fi
           git add gov.txt
           timestamp=$(date -u)
           git commit -m "Update zone file ${timestamp}" || exit 0

--- a/scripts/download_zone_file.sh
+++ b/scripts/download_zone_file.sh
@@ -1,4 +1,52 @@
-zone=$1
-token=$2
-curl --request GET --url https://api.cloudflare.com/client/v4/zones/$zone/dns_records/export --header 'Content-Type: application/json' --header "Authorization: Bearer $token"
-sed -i 's/[[:blank:]]*; cf_tags=cf-proxied:false//g' gov.txt
+#!/usr/bin/env sh
+set -eu
+
+# Read credentials from the environment so the token never appears in the
+# process list (argv is world-readable via /proc on the runner).
+zone="${CLOUDFLARE_ZONE:?CLOUDFLARE_ZONE not set}"
+token="${CLOUDFLARE_TOKEN:?CLOUDFLARE_TOKEN not set}"
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+# Fetch the BIND zone export.
+#   --fail-with-body : exit non-zero on HTTP >= 400 but still capture the body
+#                      so we can log Cloudflare's error message.
+#   --retry ...      : ride out transient 5xx / network blips.
+#   --connect-timeout / --max-time : never hang a scheduled job forever.
+http_code="$(
+  curl --silent --show-error --location \
+       --fail-with-body \
+       --retry 5 --retry-delay 5 --retry-all-errors \
+       --connect-timeout 30 --max-time 300 \
+       --write-out '%{http_code}' \
+       --request GET \
+       --url "https://api.cloudflare.com/client/v4/zones/${zone}/dns_records/export" \
+       --header 'Content-Type: application/json' \
+       --header "Authorization: Bearer ${token}" \
+       --output "$tmp"
+)" || {
+  echo "download_zone_file: curl failed (HTTP ${http_code:-none})" >&2
+  cat "$tmp" >&2 2>/dev/null || true
+  exit 1
+}
+
+# Cloudflare returns raw BIND text on success and a JSON envelope ONLY on error.
+# Reject the envelope even if it somehow arrived with HTTP 200.
+if [ "$(head -c 1 "$tmp")" = "{" ] || grep -q '"success":[[:space:]]*false' "$tmp"; then
+  echo "download_zone_file: API returned an error envelope, not a zone file:" >&2
+  cat "$tmp" >&2
+  exit 1
+fi
+
+# Sanity floor: the real .gov zone is thousands of lines. Anything
+# tiny means a truncated / bogus response, so refuse it rather than publish it.
+lines="$(wc -l < "$tmp")"
+if [ "$lines" -lt 1000 ]; then
+  echo "download_zone_file: response only ${lines} lines; refusing (looks truncated)" >&2
+  cat "$tmp" >&2
+  exit 1
+fi
+
+# Strip Cloudflare proxy tags, then emit the cleaned zone file on stdout.
+sed 's/[[:blank:]]*; cf_tags=cf-proxied:false//g' "$tmp"

--- a/scripts/download_zone_file.sh
+++ b/scripts/download_zone_file.sh
@@ -14,6 +14,9 @@ trap 'rm -f "$tmp"' EXIT
 #                      so we can log Cloudflare's error message.
 #   --retry ...      : ride out transient 5xx / network blips.
 #   --connect-timeout / --max-time : never hang a scheduled job forever.
+#
+# Capture the status code (--write-out) in http_code while the body goes to
+# $tmp (--output); the trailing || block runs only if curl exits non-zero.
 http_code="$(
   curl --silent --show-error --location \
        --fail-with-body \


### PR DESCRIPTION
Yesterday's https://github.com/cisagov/dotgov-data/commit/664cb3d56064193be1740679f497a8529847e297 pushed a change to the zone file that resulted in it being a log of a failed fetch. This was an infrastructural issue and authentication problem, both of which have been resolved. 

This PR improves the resilience of our git-scraping. It removes `flat` and `deno` as dependancies in Actions, adds some defense-in-depth (by checking zone file length in both the script + publishing workflow, and checks for known Cloudflare errors), and pins `checkout` to the latest version (the comment allows Dependabot to bump for updates even when pinned).