### PR TITLE
GitHub pages setup

### DIFF
--- a/.github/workflows/branch-preview.yml
+++ b/.github/workflows/branch-preview.yml
@@ -2,7 +2,9 @@ name: Branch preview
 
 on:
   push:
-    branches-ignore: [main]
+    branches-ignore:
+      - main
+      - gh-pages
     paths:
       - 'index.html'
 #      - '*.csv' # Removing the .csv trigger until the initial deployment
@@ -25,6 +27,12 @@ jobs:
         env:
           REF_NAME: ${{ github.ref_name }}
         run: echo "slug=$(echo "$REF_NAME" | tr '/' '-')" >> "$GITHUB_OUTPUT"
+
+      - name: Stage site files
+        run: |
+          mkdir -p _site
+          cp index.html _site/
+          cp *.csv _site/
 
       - name: Deploy preview
         id: preview

--- a/.github/workflows/branch-preview.yml
+++ b/.github/workflows/branch-preview.yml
@@ -1,0 +1,63 @@
+name: Branch preview
+
+on:
+  push:
+    branches-ignore: [main]
+    paths:
+      - 'index.html'
+#      - '*.csv' # Removing the .csv trigger until the initial deployment
+  delete:
+
+concurrency: preview-${{ github.event.ref || github.ref_name }}
+
+jobs:
+  deploy-preview:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Compute safe branch slug
+        id: slug
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: echo "slug=$(echo "$REF_NAME" | tr '/' '-')" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy preview
+        id: preview
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
+        with:
+          source-dir: ./_site
+          preview-branch: gh-pages
+          action: deploy
+          pr-number: ${{ steps.slug.outputs.slug }}
+          comment: false
+          qr-code: false
+
+      - name: Show preview URL
+        run: echo "Preview available at ${{ steps.preview.outputs.preview-url }}" >> "$GITHUB_STEP_SUMMARY"
+
+  remove-preview:
+    if: github.event_name == 'delete' && github.event.ref_type == 'branch' && github.event.ref != 'main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Compute safe branch slug
+        id: slug
+        env:
+          DELETED_REF: ${{ github.event.ref }}
+        run: echo "slug=$(echo "$DELETED_REF" | tr '/' '-')" >> "$GITHUB_OUTPUT"
+
+      - name: Remove preview
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
+        with:
+          preview-branch: gh-pages
+          action: remove
+          pr-number: ${{ steps.slug.outputs.slug }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,4 +29,4 @@ jobs:
         with:
           branch: gh-pages
           folder: _site
-          clean-exclude: pr-preview # don't wipe out active branch previews
+          clean-exclude: pr-preview # This folder is used by the rossjrw/pr-preview-action for branch previews, so exclude here so we don't wipe out active branch previews

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy to gh-pages (branch)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'index.html'
+      # - '*.csv' // Omit this until index.html is added
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Stage site files
+        run: |
+          mkdir -p _site
+          cp index.html _site/
+          cp *.csv _site/
+
+      - name: Deploy to gh-pages
+        uses: JamesIves/github-pages-deploy-action@fa24774553152dd7873cd16ebd8d959b010c5445 # v4.9.0
+        with:
+          branch: gh-pages
+          folder: _site
+          clean-exclude: pr-preview # don't wipe out active branch previews

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Note that not all registered domains offer an online service (e.g., a website, a
 
 ### GitHub Pages
 
-This repo will publish a small data browser via GitHub Pages, so that the above-referenced .csv files can be searched, sorted, and filtered without cloning the repo.
+This repo publishes a small data browser via GitHub Pages so that the CSV files named above can be searched, sorted, and filtered without needing to clone or download anything.
 
 Key things to know:
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ The [.gov top-level domain](https://get.gov) exists so that the online services 
 This repository contains the official, full list of registered domains in the .gov zone. The U.S. Government's executive, legislative, and judicial branches are represented, as are many state, territory, tribal, city, and county governments in the United States.
 
 Three files are updated daily (when there is activity):
-* [gov.txt](https://github.com/cisagov/dotgov-data/blob/main/gov.txt) – a copy of the .gov zone file
-* [current-full.csv](https://github.com/cisagov/dotgov-data/blob/main/current-full.csv) – a CSV of all domains in the zone, including federal domains
-* [current-federal.csv](https://github.com/cisagov/dotgov-data/blob/main/current-federal.csv) – a CSV of only federal domains in the zone
+* [gov.txt](https://github.com/cisagov/dotgov-data/blob/main/gov.txt) — a copy of the .gov zone file
+* [current-full.csv](https://github.com/cisagov/dotgov-data/blob/main/current-full.csv) — a CSV of all domains in the zone, including federal domains
+* [current-federal.csv](https://github.com/cisagov/dotgov-data/blob/main/current-federal.csv) — a CSV of only federal domains in the zone
 
 current-full.csv and current-federal.csv contain the same registered domains as the zone file, but instead of name server records they detail the registrant organization. They include all domains in the "Ready" and "On hold" states of our [registrar](https://github.com/cisagov/manage.get.gov/). 
 
@@ -32,3 +32,35 @@ Note that not all registered domains offer an online service (e.g., a website, a
 * Lauren Ancona made a [geocoded map of .gov domains](http://laurenancona.com/maps/gov_domains.html):
 
 [![gov_domains](https://cloud.githubusercontent.com/assets/2152151/5627069/ba4185e2-9561-11e4-873a-54d9f480ec3e.jpg)](http://laurenancona.com/maps/gov_domains.html)
+
+## For developers
+
+### GitHub Pages
+
+This repo will publish a small data browser via GitHub Pages, so that the above-referenced .csv files can be searched, sorted, and filtered without cloning the repo.
+
+Key things to know:
+
+- `main` is the canonical source of truth for index.html and the CSVs.
+- The repository is configured to deploy to GitHub Pages from a branch, `gh-pages` (not `main`). 
+- The `gh-pages` branch is a deploy target _only_ — it is managed exclusively by GitHub Actions, and developers shouldn't generally merge or interact with `gh-pages` directly.
+
+#### Workflows
+
+- **`.github/workflows/deploy.yml`** is triggered when there are changes to `index.html` or one of the `.csv` files on `main`. The workflow syncs those changes to the `gh-pages` branch to be deployed. This workflow can also be triggered manually via **Run workflow** in the Actions tab.
+- **`.github/workflows/branch-preview.yml`** publishes a temporary preview of any other branch in this repository, and removes it automatically when the branch is deleted. 
+
+### Making changes
+
+1. Branch off `main`, make changes, and push that branch to the repo.
+2. `branch-preview.yml` runs automatically. Check the **Actions** tab for the run, and open its summary to get a link to the preview.
+3. Every push to your branch will update the same preview link in-place.
+4. Open a PR when you're ready. Reviewers can use the same link to see a rendered page, not just the diff. 
+5. Merge the PR to `main` once approved.
+6. On the merge to `main`, `deploy.yml` syncs the changes to the `gh-pages` branch and it's deployed to the GitHub Pages site. 
+7. Deleting your branch (or letting GitHub do it after merge) cleans up the preview automatically.
+
+### Known limitations
+
+* **Fork PRs don't get a preview** — the preview workflow only supports branches within this repo, not PRs from a fork.
+* **Orphaned preview cleanup is manual** — if a preview is left behind outside of a normal branch deletion, it needs to be manually removed from the `gh-pages` branch using `git rm` for the folder where the preview is.


### PR DESCRIPTION
Set up the framework for GitHub Pages deployments. 

Includes:

1. a deploy action so that changes to `main` that affect the index or csv files will push to the `gh_pages` branch (the branch that will be used for GitHub Pages).
2. A branch-preview action so that changes to any other branch publish to gh-pages, but in a preview folder
3. Updated readme with details about what each workflow does, and how they will work for making changes to the GitHub-Pages deployed website.


NOTE: this doesn't yet include the index.html, because these actions need to be in place, so index.html can be published and we can set up GitHub Pages to use the right branch!