### PR TITLE
Make footer more succinct

### DIFF
--- a/index.html
+++ b/index.html
@@ -541,13 +541,10 @@
 </main>
 
 <footer>
-  <p>This is a prototype viewer for data published in the
+  <p>This is a viewer for data published in the
     <a class="repo-context" data-repo-link="root" data-repo-text="slash" href="https://github.com/cisagov/dotgov-data" target="_blank" rel="noopener">cisagov/dotgov-data</a> repository.
-    Built with <a href="https://tabulator.info/" target="_blank" rel="noopener">Tabulator</a> and
-    <a href="https://www.papaparse.com/" target="_blank" rel="noopener">PapaParse</a>, both open source.
     <span id="footer-production-note">To correct information about a domain you manage, sign in to the
     <a href="https://manage.get.gov" target="_blank" rel="noopener">.gov registrar</a>.</span>
-    <span id="footer-nonproduction-note" hidden><strong>Does not contain official .gov domain information.</strong> This repo supports the .gov registry team publishing data about the .gov zone — it's used to test format and publication changes before they ship, and may include fake .gov domains. Unless you're part of that team, this repo probably isn't useful to you.</span>
   </p>
 </footer>
 


### PR DESCRIPTION
Removed the open source info and reference to the data viewer being a prototype

[Preview of changes](https://data.get.gov/pr-preview/pr-ka-date-viewer-footer-updates/)