### PR TITLE
Fix data viewer startup on non-production deployments

### DIFF
--- a/index.html
+++ b/index.html
@@ -641,7 +641,6 @@
       document.getElementById('non-production-banner-text').textContent = 'You are viewing a non-production repository (' + REPO_CONTEXT.owner + '/' + REPO_CONTEXT.repo + '), not the live data! This may contain fake domains and data, and should NOT be used as a reference.';
       banner.hidden = false;
       document.getElementById('footer-production-note').hidden = true;
-      document.getElementById('footer-nonproduction-note').hidden = false;
       document.getElementById('h1-nonproduction-tag').hidden = false;
       // "data.get.gov" is the real production domain — showing that name
       // as the site's own title anywhere else would falsely imply this

--- a/tests/viewer-startup.test.mjs
+++ b/tests/viewer-startup.test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import vm from 'node:vm';
+
+const html = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+const scriptStart = html.lastIndexOf('<script>');
+const markup = html.slice(0, scriptStart);
+const script = html.slice(scriptStart + '<script>'.length, html.indexOf('</script>', scriptStart));
+
+for (const [url, repo, production] of [
+  ['https://data.get.gov/', 'cisagov/dotgov-data', true],
+  ['https://cisagov.github.io/dotgov-data/', 'cisagov/dotgov-data', true],
+  ['https://cisagov.github.io/dotgov-data-staging/', 'cisagov/dotgov-data-staging', false],
+  ['https://example.github.io/dotgov-data/', 'example/dotgov-data', false],
+]) {
+  for (const librariesAvailable of [true, false]) {
+    test(`${url} initializes with CDN libraries ${librariesAvailable ? 'available' : 'missing'}`, () => {
+      // Build only the startup DOM surface, using IDs from the actual markup.
+      // Missing elements must return null, as they do in a browser.
+      const elements = new Map();
+      for (const match of markup.matchAll(/<[^>]+\bid="([^"]+)"[^>]*>/g)) {
+        elements.set(match[1], {
+          hidden: /\shidden(?:\s|>|=)/.test(match[0]),
+          disabled: /\sdisabled(?:\s|>|=)/.test(match[0]),
+          textContent: '',
+          addEventListener() {},
+        });
+      }
+      const document = {
+        title: 'Data viewer | data.get.gov',
+        getElementById: id => elements.get(id) || null,
+        querySelectorAll: () => [],
+      };
+      const requests = [];
+      const context = {
+        document,
+        window: { location: new URL(url) },
+        URL,
+        URLSearchParams,
+        fetch: request => {
+          requests.push(request);
+          // Stop at file discovery. No external requests or table rendering.
+          return new Promise(() => {});
+        },
+      };
+      if (librariesAvailable) {
+        context.Tabulator = function () {};
+        context.Papa = {};
+      }
+
+      assert.doesNotThrow(() => vm.runInNewContext(script, context));
+      assert.equal(elements.get('non-production-banner').hidden, production);
+      assert.equal(elements.get('h1-nonproduction-tag').hidden, production);
+      assert.equal(elements.get('footer-production-note').hidden, !production);
+      if (!production) {
+        assert.equal(elements.get('site-title-link').textContent, new URL(url).hostname);
+        assert.ok(elements.get('non-production-banner-text').textContent.includes(repo));
+      }
+      if (librariesAvailable) {
+        assert.deepEqual(requests, [`https://api.github.com/repos/${repo}/contents/?ref=main`]);
+      } else {
+        assert.deepEqual(requests, []);
+        assert.match(elements.get('message-banner').textContent, /could not load Tabulator and PapaParse/);
+        assert.equal(elements.get('global-search').disabled, true);
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Remove the stale `footer-nonproduction-note` access left after #164. Non-production deployments now finish initialization while retaining the warning banner, hostname title and hidden production-only footer note.

Fixes #165.

## Testing

- `node --test tests/viewer-startup.test.mjs`: **8 passed**. Four fail on unchanged main.
- Additional Chromium checks load the actual page with its pinned Tabulator/PapaParse libraries and fixture CSVs. Table startup, global search and clearing filters pass for production, canonical GitHub Pages, staging and fork URLs. Both non-production URLs fail before the fix.
- The committed startup tests use Node's built-in runner with no added dependencies. They exercise initialization, not table rendering; the Chromium checks separately cover rendering.
- All browser requests were intercepted with local fixtures. No live CSV or API requests were made during testing.
